### PR TITLE
Remove StableID mapping function, it's part of the interface for components now

### DIFF
--- a/pkg/components/apiserverauth/component.go
+++ b/pkg/components/apiserverauth/component.go
@@ -42,7 +42,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/awsloadbalanceroperator/component.go
+++ b/pkg/components/awsloadbalanceroperator/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/baremetalhardwareprovisioning/baremetaloperator/component.go
+++ b/pkg/components/baremetalhardwareprovisioning/baremetaloperator/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/baremetalhardwareprovisioning/clusterapiprovider/component.go
+++ b/pkg/components/baremetalhardwareprovisioning/clusterapiprovider/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/baremetalhardwareprovisioning/clusterbaremetaloperator/component.go
+++ b/pkg/components/baremetalhardwareprovisioning/clusterbaremetaloperator/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/baremetalhardwareprovisioning/component.go
+++ b/pkg/components/baremetalhardwareprovisioning/component.go
@@ -45,7 +45,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/baremetalhardwareprovisioning/ironic/component.go
+++ b/pkg/components/baremetalhardwareprovisioning/ironic/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/baremetalhardwareprovisioning/osimageprovider/component.go
+++ b/pkg/components/baremetalhardwareprovisioning/osimageprovider/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/build/component.go
+++ b/pkg/components/build/component.go
@@ -45,7 +45,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/certmanager/component.go
+++ b/pkg/components/certmanager/component.go
@@ -42,7 +42,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcompute/baremetalprovider/component.go
+++ b/pkg/components/cloudcompute/baremetalprovider/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcompute/cloudcontrollermanager/component.go
+++ b/pkg/components/cloudcompute/cloudcontrollermanager/component.go
@@ -42,7 +42,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcompute/clusterautoscaler/component.go
+++ b/pkg/components/cloudcompute/clusterautoscaler/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcompute/ibmprovider/component.go
+++ b/pkg/components/cloudcompute/ibmprovider/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcompute/kubevirtprovider/component.go
+++ b/pkg/components/cloudcompute/kubevirtprovider/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcompute/machinehealthcheck/component.go
+++ b/pkg/components/cloudcompute/machinehealthcheck/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcompute/nutanixprovider/component.go
+++ b/pkg/components/cloudcompute/nutanixprovider/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcompute/openstackprovider/component.go
+++ b/pkg/components/cloudcompute/openstackprovider/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcompute/otherprovider/component.go
+++ b/pkg/components/cloudcompute/otherprovider/component.go
@@ -55,7 +55,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcompute/ovirtprovider/component.go
+++ b/pkg/components/cloudcompute/ovirtprovider/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcredentialoperator/component.go
+++ b/pkg/components/cloudcredentialoperator/component.go
@@ -42,7 +42,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudnativeevents/cloudeventproxy/component.go
+++ b/pkg/components/cloudnativeevents/cloudeventproxy/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudnativeevents/cloudnativeevents/component.go
+++ b/pkg/components/cloudnativeevents/cloudnativeevents/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudnativeevents/hardwareeventproxy/component.go
+++ b/pkg/components/cloudnativeevents/hardwareeventproxy/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/clusterloader/component.go
+++ b/pkg/components/clusterloader/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/clusterversionoperator/component.go
+++ b/pkg/components/clusterversionoperator/component.go
@@ -50,7 +50,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cnfcerttnf/component.go
+++ b/pkg/components/cnfcerttnf/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cnfplatformvalidation/component.go
+++ b/pkg/components/cnfplatformvalidation/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/complianceoperator/component.go
+++ b/pkg/components/complianceoperator/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/component.go
+++ b/pkg/components/component.go
@@ -36,7 +36,7 @@ func IdentifyTest(reg *registry.Registry, test *v1.TestInfo) (*v1.TestOwnership,
 
 	if len(ownerships) == 0 {
 		ownerships = append(ownerships, setDefaults(test, &v1.TestOwnership{
-			ID:   fmt.Sprintf("%x", md5.Sum([]byte(util.StableID(test, nil)))),
+			ID:   fmt.Sprintf("%x", md5.Sum([]byte(util.StableID(test)))),
 			Name: test.Name,
 		}, nil))
 	}
@@ -46,7 +46,7 @@ func IdentifyTest(reg *registry.Registry, test *v1.TestInfo) (*v1.TestOwnership,
 
 func setDefaults(testInfo *v1.TestInfo, testOwnership *v1.TestOwnership, c v1.Component) *v1.TestOwnership {
 	if testOwnership.ID == "" && c != nil {
-		testOwnership.ID = fmt.Sprintf("%x", md5.Sum([]byte(util.StableID(testInfo, nil))))
+		testOwnership.ID = fmt.Sprintf("%x", md5.Sum([]byte(c.StableID(testInfo))))
 	}
 
 	testOwnership.Kind = v1.Kind

--- a/pkg/components/configoperator/component.go
+++ b/pkg/components/configoperator/component.go
@@ -42,7 +42,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/consolekubevirtplugin/component.go
+++ b/pkg/components/consolekubevirtplugin/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/consolemetal3plugin/component.go
+++ b/pkg/components/consolemetal3plugin/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/consolestorageplugin/component.go
+++ b/pkg/components/consolestorageplugin/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/containers/component.go
+++ b/pkg/components/containers/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/crc/component.go
+++ b/pkg/components/crc/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/descheduler/component.go
+++ b/pkg/components/descheduler/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/devconsole/component.go
+++ b/pkg/components/devconsole/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/drivertoolkit/component.go
+++ b/pkg/components/drivertoolkit/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/etcd/component.go
+++ b/pkg/components/etcd/component.go
@@ -51,7 +51,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/example/component.go
+++ b/pkg/components/example/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/externaldnsoperator/component.go
+++ b/pkg/components/externaldnsoperator/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/fileintegrityoperator/component.go
+++ b/pkg/components/fileintegrityoperator/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/hawkular/component.go
+++ b/pkg/components/hawkular/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/helm/component.go
+++ b/pkg/components/helm/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/hive/component.go
+++ b/pkg/components/hive/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/hypershift/component.go
+++ b/pkg/components/hypershift/component.go
@@ -42,7 +42,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/ibmrokstoolkit/component.go
+++ b/pkg/components/ibmrokstoolkit/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/imageregistry/component.go
+++ b/pkg/components/imageregistry/component.go
@@ -48,7 +48,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/imagestreams/component.go
+++ b/pkg/components/imagestreams/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/insightsoperator/component.go
+++ b/pkg/components/insightsoperator/component.go
@@ -45,7 +45,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/agentbasedinstallation/component.go
+++ b/pkg/components/installer/agentbasedinstallation/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/alibabacloud/component.go
+++ b/pkg/components/installer/alibabacloud/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/assistedinstaller/component.go
+++ b/pkg/components/installer/assistedinstaller/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/ibmcloud/component.go
+++ b/pkg/components/installer/ibmcloud/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/nutanix/component.go
+++ b/pkg/components/installer/nutanix/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/openshiftansible/component.go
+++ b/pkg/components/installer/openshiftansible/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/openshiftinstaller/component.go
+++ b/pkg/components/installer/openshiftinstaller/component.go
@@ -49,7 +49,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/openshiftonbaremetalipi/component.go
+++ b/pkg/components/installer/openshiftonbaremetalipi/component.go
@@ -43,7 +43,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/openshiftonkubevirt/component.go
+++ b/pkg/components/installer/openshiftonkubevirt/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/openshiftonopenstack/component.go
+++ b/pkg/components/installer/openshiftonopenstack/component.go
@@ -43,7 +43,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/openshiftonrhv/component.go
+++ b/pkg/components/installer/openshiftonrhv/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/powervs/component.go
+++ b/pkg/components/installer/powervs/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/singlenodeopenshift/component.go
+++ b/pkg/components/installer/singlenodeopenshift/component.go
@@ -42,7 +42,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/isvoperators/component.go
+++ b/pkg/components/isvoperators/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/jenkins/component.go
+++ b/pkg/components/jenkins/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/kmm/component.go
+++ b/pkg/components/kmm/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/kubeapiserver/component.go
+++ b/pkg/components/kubeapiserver/component.go
@@ -55,7 +55,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/kubecontrollermanager/component.go
+++ b/pkg/components/kubecontrollermanager/component.go
@@ -42,7 +42,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/kubescheduler/component.go
+++ b/pkg/components/kubescheduler/component.go
@@ -46,7 +46,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/kubestorageversionmigrator/component.go
+++ b/pkg/components/kubestorageversionmigrator/component.go
@@ -42,7 +42,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/logging/component.go
+++ b/pkg/components/logging/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/lvms/component.go
+++ b/pkg/components/lvms/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/machineconfigoperator/component.go
+++ b/pkg/components/machineconfigoperator/component.go
@@ -53,7 +53,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/machineconfigoperator/platformbaremetal/component.go
+++ b/pkg/components/machineconfigoperator/platformbaremetal/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/machineconfigoperator/platformnone/component.go
+++ b/pkg/components/machineconfigoperator/platformnone/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/machineconfigoperator/platformopenstack/component.go
+++ b/pkg/components/machineconfigoperator/platformopenstack/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/machineconfigoperator/platformovirtrhv/component.go
+++ b/pkg/components/machineconfigoperator/platformovirtrhv/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/machineconfigoperator/platformvsphere/component.go
+++ b/pkg/components/machineconfigoperator/platformvsphere/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/managementconsole/component.go
+++ b/pkg/components/managementconsole/component.go
@@ -42,7 +42,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/meteringoperator/component.go
+++ b/pkg/components/meteringoperator/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/microshift/component.go
+++ b/pkg/components/microshift/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/microshift/networking/component.go
+++ b/pkg/components/microshift/networking/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/microshift/storage/component.go
+++ b/pkg/components/microshift/storage/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/monitoring/component.go
+++ b/pkg/components/monitoring/component.go
@@ -52,7 +52,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/monitoring/grafana/component.go
+++ b/pkg/components/monitoring/grafana/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/multiarch/arm/component.go
+++ b/pkg/components/multiarch/arm/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/multiarch/component.go
+++ b/pkg/components/multiarch/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/multiarch/ibmpandz/component.go
+++ b/pkg/components/multiarch/ibmpandz/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/cloudnetworkconfigcontroller/component.go
+++ b/pkg/components/networking/cloudnetworkconfigcontroller/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/clusternetworkoperator/component.go
+++ b/pkg/components/networking/clusternetworkoperator/component.go
@@ -53,7 +53,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/dns/component.go
+++ b/pkg/components/networking/dns/component.go
@@ -53,7 +53,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/ingressnodefirewall/component.go
+++ b/pkg/components/networking/ingressnodefirewall/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/kubernetesnmstate/component.go
+++ b/pkg/components/networking/kubernetesnmstate/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/kubernetesnmstateoperator/component.go
+++ b/pkg/components/networking/kubernetesnmstateoperator/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/kuryr/component.go
+++ b/pkg/components/networking/kuryr/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/mdns/component.go
+++ b/pkg/components/networking/mdns/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/metallb/component.go
+++ b/pkg/components/networking/metallb/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/multus/component.go
+++ b/pkg/components/networking/multus/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/netobs/component.go
+++ b/pkg/components/networking/netobs/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/nmstateconsoleplugin/component.go
+++ b/pkg/components/networking/nmstateconsoleplugin/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/openshiftsdn/component.go
+++ b/pkg/components/networking/openshiftsdn/component.go
@@ -46,7 +46,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/ovnkubernetes/component.go
+++ b/pkg/components/networking/ovnkubernetes/component.go
@@ -47,7 +47,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/ptp/component.go
+++ b/pkg/components/networking/ptp/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/router/component.go
+++ b/pkg/components/networking/router/component.go
@@ -62,7 +62,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/runtimecfg/component.go
+++ b/pkg/components/networking/runtimecfg/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/sriov/component.go
+++ b/pkg/components/networking/sriov/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/autoscaler/component.go
+++ b/pkg/components/node/autoscaler/component.go
@@ -42,7 +42,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/clusterresourceoverrideadmissionoperator/component.go
+++ b/pkg/components/node/clusterresourceoverrideadmissionoperator/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/cpumanager/component.go
+++ b/pkg/components/node/cpumanager/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/crio/component.go
+++ b/pkg/components/node/crio/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/devicemanager/component.go
+++ b/pkg/components/node/devicemanager/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/kubelet/component.go
+++ b/pkg/components/node/kubelet/component.go
@@ -46,7 +46,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/memorymanager/component.go
+++ b/pkg/components/node/memorymanager/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/nodeproblemdetector/component.go
+++ b/pkg/components/node/nodeproblemdetector/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/numaawarescheduling/component.go
+++ b/pkg/components/node/numaawarescheduling/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/podresourceapi/component.go
+++ b/pkg/components/node/podresourceapi/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/topologymanager/component.go
+++ b/pkg/components/node/topologymanager/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/nodefeaturediscoveryoperator/component.go
+++ b/pkg/components/nodefeaturediscoveryoperator/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/nodemaintenanceoperator/component.go
+++ b/pkg/components/nodemaintenanceoperator/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/nodeobservabilityoperator/component.go
+++ b/pkg/components/nodeobservabilityoperator/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/nodetuningoperator/component.go
+++ b/pkg/components/nodetuningoperator/component.go
@@ -42,7 +42,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/none/component.go
+++ b/pkg/components/none/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/oauthapiserver/component.go
+++ b/pkg/components/oauthapiserver/component.go
@@ -48,7 +48,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/oauthproxy/component.go
+++ b/pkg/components/oauthproxy/component.go
@@ -42,7 +42,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/observabilityui/component.go
+++ b/pkg/components/observabilityui/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/oc/component.go
+++ b/pkg/components/oc/component.go
@@ -42,7 +42,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/oc/ocmirror/component.go
+++ b/pkg/components/oc/ocmirror/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/occompliance/component.go
+++ b/pkg/components/occompliance/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/olm/component.go
+++ b/pkg/components/olm/component.go
@@ -48,7 +48,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/olm/operatorhub/component.go
+++ b/pkg/components/olm/operatorhub/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/olm/registry/component.go
+++ b/pkg/components/olm/registry/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/openshiftapiserver/component.go
+++ b/pkg/components/openshiftapiserver/component.go
@@ -45,7 +45,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/openshiftcontrollermanager/apps/component.go
+++ b/pkg/components/openshiftcontrollermanager/apps/component.go
@@ -42,7 +42,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/openshiftcontrollermanager/build/component.go
+++ b/pkg/components/openshiftcontrollermanager/build/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/openshiftcontrollermanager/controllermanager/component.go
+++ b/pkg/components/openshiftcontrollermanager/controllermanager/component.go
@@ -42,7 +42,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/openshiftupdateservice/operand/component.go
+++ b/pkg/components/openshiftupdateservice/operand/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/openshiftupdateservice/operator/component.go
+++ b/pkg/components/openshiftupdateservice/operator/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/operatorsdk/component.go
+++ b/pkg/components/operatorsdk/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/performanceaddonoperator/component.go
+++ b/pkg/components/performanceaddonoperator/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/poisonpilloperator/component.go
+++ b/pkg/components/poisonpilloperator/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/registryconsole/component.go
+++ b/pkg/components/registryconsole/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/release/component.go
+++ b/pkg/components/release/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/rhcos/component.go
+++ b/pkg/components/rhcos/component.go
@@ -42,7 +42,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/rhmimonitoring/component.go
+++ b/pkg/components/rhmimonitoring/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/routecontrollermanager/component.go
+++ b/pkg/components/routecontrollermanager/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/runoncedurationoverride/component.go
+++ b/pkg/components/runoncedurationoverride/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/samplesoperator/component.go
+++ b/pkg/components/samplesoperator/component.go
@@ -45,7 +45,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/sandboxedcontainers/component.go
+++ b/pkg/components/sandboxedcontainers/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/secondaryscheduleroperator/component.go
+++ b/pkg/components/secondaryscheduleroperator/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/security/component.go
+++ b/pkg/components/security/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/securityprofilesoperator/component.go
+++ b/pkg/components/securityprofilesoperator/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/servicebinding/component.go
+++ b/pkg/components/servicebinding/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/servicebroker/component.go
+++ b/pkg/components/servicebroker/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/serviceca/component.go
+++ b/pkg/components/serviceca/component.go
@@ -42,7 +42,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/servicecatalog/component.go
+++ b/pkg/components/servicecatalog/component.go
@@ -45,7 +45,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/specialresourceoperator/component.go
+++ b/pkg/components/specialresourceoperator/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/storage/component.go
+++ b/pkg/components/storage/component.go
@@ -48,7 +48,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/storage/kubernetes/component.go
+++ b/pkg/components/storage/kubernetes/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/storage/kubernetesexternalcomponents/component.go
+++ b/pkg/components/storage/kubernetesexternalcomponents/component.go
@@ -42,7 +42,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/storage/localstorageoperator/component.go
+++ b/pkg/components/storage/localstorageoperator/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/storage/openstackcsidrivers/component.go
+++ b/pkg/components/storage/openstackcsidrivers/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/storage/operators/component.go
+++ b/pkg/components/storage/operators/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/storage/ovirtcsidriver/component.go
+++ b/pkg/components/storage/ovirtcsidriver/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/storage/sharedresourcecsidriver/component.go
+++ b/pkg/components/storage/sharedresourcecsidriver/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/telcoedge/hweventoperator/component.go
+++ b/pkg/components/telcoedge/hweventoperator/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/telcoedge/ran/component.go
+++ b/pkg/components/telcoedge/ran/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/telcoedge/talo/component.go
+++ b/pkg/components/telcoedge/talo/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/telcoedge/ztp/component.go
+++ b/pkg/components/telcoedge/ztp/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/telemeter/component.go
+++ b/pkg/components/telemeter/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/templates/component.go
+++ b/pkg/components/templates/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/testframework/component.go
+++ b/pkg/components/testframework/component.go
@@ -72,7 +72,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/testframework/openstack/component.go
+++ b/pkg/components/testframework/openstack/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/testinfrastructure/component.go
+++ b/pkg/components/testinfrastructure/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/topolvm/component.go
+++ b/pkg/components/topolvm/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/unknown/component.go
+++ b/pkg/components/unknown/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/virtualization/component.go
+++ b/pkg/components/virtualization/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/windowscontainers/component.go
+++ b/pkg/components/windowscontainers/component.go
@@ -38,7 +38,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test, nil)
+	return util.StableID(test)
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/util/tests.go
+++ b/pkg/util/tests.go
@@ -23,13 +23,9 @@ func ExtractTestField(testName, field string) (results []string) {
 	return results
 }
 
-// StableID produces a stable test ID based on a TestInfo struct, and a stable name mapping function.
-// The mapper function can be used to handle test renames.
-func StableID(testInfo *v1.TestInfo, mapper func(string) string) string {
+// StableID produces a stable test ID based on a TestInfo struct.
+func StableID(testInfo *v1.TestInfo) string {
 	testName := testInfo.Name
-	if mapper != nil {
-		testName = mapper(testInfo.Name)
-	}
 
 	if testInfo.Suite != "" {
 		return fmt.Sprintf("%s.%s", testInfo.Suite, testName)


### PR DESCRIPTION
The mapper argument to the StableID helper was an old implementation detail and isn't needed anymore, as StableID was elevated to the interface.
