### PR TITLE
Match Justin's implementation of test ID's

### DIFF
--- a/pkg/components/apiserverauth/component.go
+++ b/pkg/components/apiserverauth/component.go
@@ -3,7 +3,6 @@ package apiserverauth
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -42,7 +41,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/awsloadbalanceroperator/component.go
+++ b/pkg/components/awsloadbalanceroperator/component.go
@@ -3,7 +3,6 @@ package awsloadbalanceroperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/baremetalhardwareprovisioning/baremetaloperator/component.go
+++ b/pkg/components/baremetalhardwareprovisioning/baremetaloperator/component.go
@@ -3,7 +3,6 @@ package baremetalhardwareprovisioningbaremetaloperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/baremetalhardwareprovisioning/clusterapiprovider/component.go
+++ b/pkg/components/baremetalhardwareprovisioning/clusterapiprovider/component.go
@@ -3,7 +3,6 @@ package baremetalhardwareprovisioningclusterapiprovider
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/baremetalhardwareprovisioning/clusterbaremetaloperator/component.go
+++ b/pkg/components/baremetalhardwareprovisioning/clusterbaremetaloperator/component.go
@@ -3,7 +3,6 @@ package baremetalhardwareprovisioningclusterbaremetaloperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/baremetalhardwareprovisioning/component.go
+++ b/pkg/components/baremetalhardwareprovisioning/component.go
@@ -3,7 +3,6 @@ package baremetalhardwareprovisioning
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -45,7 +44,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/baremetalhardwareprovisioning/ironic/component.go
+++ b/pkg/components/baremetalhardwareprovisioning/ironic/component.go
@@ -3,7 +3,6 @@ package baremetalhardwareprovisioningironic
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/baremetalhardwareprovisioning/osimageprovider/component.go
+++ b/pkg/components/baremetalhardwareprovisioning/osimageprovider/component.go
@@ -3,7 +3,6 @@ package baremetalhardwareprovisioningosimageprovider
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/build/component.go
+++ b/pkg/components/build/component.go
@@ -3,7 +3,6 @@ package build
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -45,7 +44,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/certmanager/component.go
+++ b/pkg/components/certmanager/component.go
@@ -3,7 +3,6 @@ package certmanager
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -42,7 +41,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcompute/baremetalprovider/component.go
+++ b/pkg/components/cloudcompute/baremetalprovider/component.go
@@ -3,7 +3,6 @@ package cloudcomputebaremetalprovider
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcompute/cloudcontrollermanager/component.go
+++ b/pkg/components/cloudcompute/cloudcontrollermanager/component.go
@@ -3,7 +3,6 @@ package cloudcomputecloudcontrollermanager
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -42,7 +41,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcompute/clusterautoscaler/component.go
+++ b/pkg/components/cloudcompute/clusterautoscaler/component.go
@@ -3,7 +3,6 @@ package cloudcomputeclusterautoscaler
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcompute/ibmprovider/component.go
+++ b/pkg/components/cloudcompute/ibmprovider/component.go
@@ -3,7 +3,6 @@ package cloudcomputeibmprovider
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcompute/kubevirtprovider/component.go
+++ b/pkg/components/cloudcompute/kubevirtprovider/component.go
@@ -3,7 +3,6 @@ package cloudcomputekubevirtprovider
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcompute/machinehealthcheck/component.go
+++ b/pkg/components/cloudcompute/machinehealthcheck/component.go
@@ -3,7 +3,6 @@ package cloudcomputemachinehealthcheck
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcompute/nutanixprovider/component.go
+++ b/pkg/components/cloudcompute/nutanixprovider/component.go
@@ -3,7 +3,6 @@ package cloudcomputenutanixprovider
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcompute/openstackprovider/component.go
+++ b/pkg/components/cloudcompute/openstackprovider/component.go
@@ -3,7 +3,6 @@ package cloudcomputeopenstackprovider
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcompute/otherprovider/component.go
+++ b/pkg/components/cloudcompute/otherprovider/component.go
@@ -3,7 +3,6 @@ package cloudcomputeotherprovider
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -55,7 +54,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcompute/ovirtprovider/component.go
+++ b/pkg/components/cloudcompute/ovirtprovider/component.go
@@ -3,7 +3,6 @@ package cloudcomputeovirtprovider
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudcredentialoperator/component.go
+++ b/pkg/components/cloudcredentialoperator/component.go
@@ -3,7 +3,6 @@ package cloudcredentialoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -42,7 +41,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudnativeevents/cloudeventproxy/component.go
+++ b/pkg/components/cloudnativeevents/cloudeventproxy/component.go
@@ -3,7 +3,6 @@ package cloudnativeeventscloudeventproxy
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudnativeevents/cloudnativeevents/component.go
+++ b/pkg/components/cloudnativeevents/cloudnativeevents/component.go
@@ -3,7 +3,6 @@ package cloudnativeeventscloudnativeevents
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cloudnativeevents/hardwareeventproxy/component.go
+++ b/pkg/components/cloudnativeevents/hardwareeventproxy/component.go
@@ -3,7 +3,6 @@ package cloudnativeeventshardwareeventproxy
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/clusterloader/component.go
+++ b/pkg/components/clusterloader/component.go
@@ -3,7 +3,6 @@ package clusterloader
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/clusterversionoperator/component.go
+++ b/pkg/components/clusterversionoperator/component.go
@@ -3,7 +3,6 @@ package clusterversionoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -50,7 +49,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cnfcerttnf/component.go
+++ b/pkg/components/cnfcerttnf/component.go
@@ -3,7 +3,6 @@ package cnfcerttnf
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/cnfplatformvalidation/component.go
+++ b/pkg/components/cnfplatformvalidation/component.go
@@ -3,7 +3,6 @@ package cnfplatformvalidation
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/complianceoperator/component.go
+++ b/pkg/components/complianceoperator/component.go
@@ -3,7 +3,6 @@ package complianceoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/component.go
+++ b/pkg/components/component.go
@@ -1,7 +1,6 @@
 package components
 
 import (
-	"crypto/md5"
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
@@ -36,7 +35,7 @@ func IdentifyTest(reg *registry.Registry, test *v1.TestInfo) (*v1.TestOwnership,
 
 	if len(ownerships) == 0 {
 		ownerships = append(ownerships, setDefaults(test, &v1.TestOwnership{
-			ID:   fmt.Sprintf("%x", md5.Sum([]byte(util.StableID(test)))),
+			ID:   util.StableID(test, util.StableID(test, test.Name)),
 			Name: test.Name,
 		}, nil))
 	}
@@ -46,7 +45,7 @@ func IdentifyTest(reg *registry.Registry, test *v1.TestInfo) (*v1.TestOwnership,
 
 func setDefaults(testInfo *v1.TestInfo, testOwnership *v1.TestOwnership, c v1.Component) *v1.TestOwnership {
 	if testOwnership.ID == "" && c != nil {
-		testOwnership.ID = fmt.Sprintf("%x", md5.Sum([]byte(c.StableID(testInfo))))
+		testOwnership.ID = util.StableID(testInfo, c.StableID(testInfo))
 	}
 
 	testOwnership.Kind = v1.Kind

--- a/pkg/components/configoperator/component.go
+++ b/pkg/components/configoperator/component.go
@@ -3,7 +3,6 @@ package configoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -42,7 +41,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/consolekubevirtplugin/component.go
+++ b/pkg/components/consolekubevirtplugin/component.go
@@ -3,7 +3,6 @@ package consolekubevirtplugin
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/consolemetal3plugin/component.go
+++ b/pkg/components/consolemetal3plugin/component.go
@@ -3,7 +3,6 @@ package consolemetal3plugin
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/consolestorageplugin/component.go
+++ b/pkg/components/consolestorageplugin/component.go
@@ -3,7 +3,6 @@ package consolestorageplugin
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/containers/component.go
+++ b/pkg/components/containers/component.go
@@ -3,7 +3,6 @@ package containers
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/crc/component.go
+++ b/pkg/components/crc/component.go
@@ -3,7 +3,6 @@ package crc
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/descheduler/component.go
+++ b/pkg/components/descheduler/component.go
@@ -3,7 +3,6 @@ package descheduler
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/devconsole/component.go
+++ b/pkg/components/devconsole/component.go
@@ -3,7 +3,6 @@ package devconsole
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/drivertoolkit/component.go
+++ b/pkg/components/drivertoolkit/component.go
@@ -3,7 +3,6 @@ package drivertoolkit
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/etcd/component.go
+++ b/pkg/components/etcd/component.go
@@ -3,7 +3,6 @@ package etcd
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -51,7 +50,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/example/component.go
+++ b/pkg/components/example/component.go
@@ -3,7 +3,6 @@ package example
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/externaldnsoperator/component.go
+++ b/pkg/components/externaldnsoperator/component.go
@@ -3,7 +3,6 @@ package externaldnsoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/fileintegrityoperator/component.go
+++ b/pkg/components/fileintegrityoperator/component.go
@@ -3,7 +3,6 @@ package fileintegrityoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/hawkular/component.go
+++ b/pkg/components/hawkular/component.go
@@ -3,7 +3,6 @@ package hawkular
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/helm/component.go
+++ b/pkg/components/helm/component.go
@@ -3,7 +3,6 @@ package helm
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/hive/component.go
+++ b/pkg/components/hive/component.go
@@ -3,7 +3,6 @@ package hive
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/hypershift/component.go
+++ b/pkg/components/hypershift/component.go
@@ -3,7 +3,6 @@ package hypershift
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -42,7 +41,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/ibmrokstoolkit/component.go
+++ b/pkg/components/ibmrokstoolkit/component.go
@@ -3,7 +3,6 @@ package ibmrokstoolkit
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/imageregistry/component.go
+++ b/pkg/components/imageregistry/component.go
@@ -3,7 +3,6 @@ package imageregistry
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -48,7 +47,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/imagestreams/component.go
+++ b/pkg/components/imagestreams/component.go
@@ -3,7 +3,6 @@ package imagestreams
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/insightsoperator/component.go
+++ b/pkg/components/insightsoperator/component.go
@@ -3,7 +3,6 @@ package insightsoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -45,7 +44,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/agentbasedinstallation/component.go
+++ b/pkg/components/installer/agentbasedinstallation/component.go
@@ -3,7 +3,6 @@ package installeragentbasedinstallation
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/alibabacloud/component.go
+++ b/pkg/components/installer/alibabacloud/component.go
@@ -3,7 +3,6 @@ package installeralibabacloud
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/assistedinstaller/component.go
+++ b/pkg/components/installer/assistedinstaller/component.go
@@ -3,7 +3,6 @@ package installerassistedinstaller
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/ibmcloud/component.go
+++ b/pkg/components/installer/ibmcloud/component.go
@@ -3,7 +3,6 @@ package installeribmcloud
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/nutanix/component.go
+++ b/pkg/components/installer/nutanix/component.go
@@ -3,7 +3,6 @@ package installernutanix
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/openshiftansible/component.go
+++ b/pkg/components/installer/openshiftansible/component.go
@@ -3,7 +3,6 @@ package installeropenshiftansible
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/openshiftinstaller/component.go
+++ b/pkg/components/installer/openshiftinstaller/component.go
@@ -3,7 +3,6 @@ package installeropenshiftinstaller
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -49,7 +48,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/openshiftonbaremetalipi/component.go
+++ b/pkg/components/installer/openshiftonbaremetalipi/component.go
@@ -3,7 +3,6 @@ package installeropenshiftonbaremetalipi
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -43,7 +42,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/openshiftonkubevirt/component.go
+++ b/pkg/components/installer/openshiftonkubevirt/component.go
@@ -3,7 +3,6 @@ package installeropenshiftonkubevirt
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/openshiftonopenstack/component.go
+++ b/pkg/components/installer/openshiftonopenstack/component.go
@@ -3,7 +3,6 @@ package installeropenshiftonopenstack
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -43,7 +42,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/openshiftonrhv/component.go
+++ b/pkg/components/installer/openshiftonrhv/component.go
@@ -3,7 +3,6 @@ package installeropenshiftonrhv
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/powervs/component.go
+++ b/pkg/components/installer/powervs/component.go
@@ -3,7 +3,6 @@ package installerpowervs
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/installer/singlenodeopenshift/component.go
+++ b/pkg/components/installer/singlenodeopenshift/component.go
@@ -3,7 +3,6 @@ package installersinglenodeopenshift
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -42,7 +41,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/isvoperators/component.go
+++ b/pkg/components/isvoperators/component.go
@@ -3,7 +3,6 @@ package isvoperators
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/jenkins/component.go
+++ b/pkg/components/jenkins/component.go
@@ -3,7 +3,6 @@ package jenkins
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/kmm/component.go
+++ b/pkg/components/kmm/component.go
@@ -3,7 +3,6 @@ package kmm
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/kubeapiserver/component.go
+++ b/pkg/components/kubeapiserver/component.go
@@ -3,7 +3,6 @@ package kubeapiserver
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -55,7 +54,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/kubecontrollermanager/component.go
+++ b/pkg/components/kubecontrollermanager/component.go
@@ -3,7 +3,6 @@ package kubecontrollermanager
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -42,7 +41,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/kubescheduler/component.go
+++ b/pkg/components/kubescheduler/component.go
@@ -3,7 +3,6 @@ package kubescheduler
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -46,7 +45,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/kubestorageversionmigrator/component.go
+++ b/pkg/components/kubestorageversionmigrator/component.go
@@ -3,7 +3,6 @@ package kubestorageversionmigrator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -42,7 +41,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/logging/component.go
+++ b/pkg/components/logging/component.go
@@ -3,7 +3,6 @@ package logging
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/lvms/component.go
+++ b/pkg/components/lvms/component.go
@@ -3,7 +3,6 @@ package lvms
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/machineconfigoperator/component.go
+++ b/pkg/components/machineconfigoperator/component.go
@@ -3,7 +3,6 @@ package machineconfigoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -53,7 +52,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/machineconfigoperator/platformbaremetal/component.go
+++ b/pkg/components/machineconfigoperator/platformbaremetal/component.go
@@ -3,7 +3,6 @@ package machineconfigoperatorplatformbaremetal
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/machineconfigoperator/platformnone/component.go
+++ b/pkg/components/machineconfigoperator/platformnone/component.go
@@ -3,7 +3,6 @@ package machineconfigoperatorplatformnone
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/machineconfigoperator/platformopenstack/component.go
+++ b/pkg/components/machineconfigoperator/platformopenstack/component.go
@@ -3,7 +3,6 @@ package machineconfigoperatorplatformopenstack
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/machineconfigoperator/platformovirtrhv/component.go
+++ b/pkg/components/machineconfigoperator/platformovirtrhv/component.go
@@ -3,7 +3,6 @@ package machineconfigoperatorplatformovirtrhv
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/machineconfigoperator/platformvsphere/component.go
+++ b/pkg/components/machineconfigoperator/platformvsphere/component.go
@@ -3,7 +3,6 @@ package machineconfigoperatorplatformvsphere
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/managementconsole/component.go
+++ b/pkg/components/managementconsole/component.go
@@ -3,7 +3,6 @@ package managementconsole
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -42,7 +41,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/meteringoperator/component.go
+++ b/pkg/components/meteringoperator/component.go
@@ -3,7 +3,6 @@ package meteringoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/microshift/component.go
+++ b/pkg/components/microshift/component.go
@@ -3,7 +3,6 @@ package microshift
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/microshift/networking/component.go
+++ b/pkg/components/microshift/networking/component.go
@@ -3,7 +3,6 @@ package microshiftnetworking
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/microshift/storage/component.go
+++ b/pkg/components/microshift/storage/component.go
@@ -3,7 +3,6 @@ package microshiftstorage
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/monitoring/component.go
+++ b/pkg/components/monitoring/component.go
@@ -3,7 +3,6 @@ package monitoring
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -52,7 +51,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/monitoring/grafana/component.go
+++ b/pkg/components/monitoring/grafana/component.go
@@ -3,7 +3,6 @@ package monitoringgrafana
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/multiarch/arm/component.go
+++ b/pkg/components/multiarch/arm/component.go
@@ -3,7 +3,6 @@ package multiarcharm
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/multiarch/component.go
+++ b/pkg/components/multiarch/component.go
@@ -3,7 +3,6 @@ package multiarch
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/multiarch/ibmpandz/component.go
+++ b/pkg/components/multiarch/ibmpandz/component.go
@@ -3,7 +3,6 @@ package multiarchibmpandz
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/cloudnetworkconfigcontroller/component.go
+++ b/pkg/components/networking/cloudnetworkconfigcontroller/component.go
@@ -3,7 +3,6 @@ package networkingcloudnetworkconfigcontroller
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/clusternetworkoperator/component.go
+++ b/pkg/components/networking/clusternetworkoperator/component.go
@@ -3,7 +3,6 @@ package networkingclusternetworkoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -53,7 +52,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/dns/component.go
+++ b/pkg/components/networking/dns/component.go
@@ -3,7 +3,6 @@ package networkingdns
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -53,7 +52,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/ingressnodefirewall/component.go
+++ b/pkg/components/networking/ingressnodefirewall/component.go
@@ -3,7 +3,6 @@ package networkingingressnodefirewall
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/kubernetesnmstate/component.go
+++ b/pkg/components/networking/kubernetesnmstate/component.go
@@ -3,7 +3,6 @@ package networkingkubernetesnmstate
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/kubernetesnmstateoperator/component.go
+++ b/pkg/components/networking/kubernetesnmstateoperator/component.go
@@ -3,7 +3,6 @@ package networkingkubernetesnmstateoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/kuryr/component.go
+++ b/pkg/components/networking/kuryr/component.go
@@ -3,7 +3,6 @@ package networkingkuryr
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/mdns/component.go
+++ b/pkg/components/networking/mdns/component.go
@@ -3,7 +3,6 @@ package networkingmdns
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/metallb/component.go
+++ b/pkg/components/networking/metallb/component.go
@@ -3,7 +3,6 @@ package networkingmetallb
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/multus/component.go
+++ b/pkg/components/networking/multus/component.go
@@ -3,7 +3,6 @@ package networkingmultus
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/netobs/component.go
+++ b/pkg/components/networking/netobs/component.go
@@ -3,7 +3,6 @@ package networkingnetobs
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/nmstateconsoleplugin/component.go
+++ b/pkg/components/networking/nmstateconsoleplugin/component.go
@@ -3,7 +3,6 @@ package networkingnmstateconsoleplugin
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/openshiftsdn/component.go
+++ b/pkg/components/networking/openshiftsdn/component.go
@@ -3,7 +3,6 @@ package networkingopenshiftsdn
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -46,7 +45,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/ovnkubernetes/component.go
+++ b/pkg/components/networking/ovnkubernetes/component.go
@@ -3,7 +3,6 @@ package networkingovnkubernetes
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -47,7 +46,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/ptp/component.go
+++ b/pkg/components/networking/ptp/component.go
@@ -3,7 +3,6 @@ package networkingptp
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/router/component.go
+++ b/pkg/components/networking/router/component.go
@@ -3,7 +3,6 @@ package networkingrouter
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -62,7 +61,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/runtimecfg/component.go
+++ b/pkg/components/networking/runtimecfg/component.go
@@ -3,7 +3,6 @@ package networkingruntimecfg
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/networking/sriov/component.go
+++ b/pkg/components/networking/sriov/component.go
@@ -3,7 +3,6 @@ package networkingsriov
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/autoscaler/component.go
+++ b/pkg/components/node/autoscaler/component.go
@@ -3,7 +3,6 @@ package nodeautoscaler
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -42,7 +41,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/clusterresourceoverrideadmissionoperator/component.go
+++ b/pkg/components/node/clusterresourceoverrideadmissionoperator/component.go
@@ -3,7 +3,6 @@ package nodeclusterresourceoverrideadmissionoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/cpumanager/component.go
+++ b/pkg/components/node/cpumanager/component.go
@@ -3,7 +3,6 @@ package nodecpumanager
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/crio/component.go
+++ b/pkg/components/node/crio/component.go
@@ -3,7 +3,6 @@ package nodecrio
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/devicemanager/component.go
+++ b/pkg/components/node/devicemanager/component.go
@@ -3,7 +3,6 @@ package nodedevicemanager
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/kubelet/component.go
+++ b/pkg/components/node/kubelet/component.go
@@ -3,7 +3,6 @@ package nodekubelet
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -46,7 +45,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/memorymanager/component.go
+++ b/pkg/components/node/memorymanager/component.go
@@ -3,7 +3,6 @@ package nodememorymanager
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/nodeproblemdetector/component.go
+++ b/pkg/components/node/nodeproblemdetector/component.go
@@ -3,7 +3,6 @@ package nodenodeproblemdetector
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/numaawarescheduling/component.go
+++ b/pkg/components/node/numaawarescheduling/component.go
@@ -3,7 +3,6 @@ package nodenumaawarescheduling
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/podresourceapi/component.go
+++ b/pkg/components/node/podresourceapi/component.go
@@ -3,7 +3,6 @@ package nodepodresourceapi
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/node/topologymanager/component.go
+++ b/pkg/components/node/topologymanager/component.go
@@ -3,7 +3,6 @@ package nodetopologymanager
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/nodefeaturediscoveryoperator/component.go
+++ b/pkg/components/nodefeaturediscoveryoperator/component.go
@@ -3,7 +3,6 @@ package nodefeaturediscoveryoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/nodemaintenanceoperator/component.go
+++ b/pkg/components/nodemaintenanceoperator/component.go
@@ -3,7 +3,6 @@ package nodemaintenanceoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/nodeobservabilityoperator/component.go
+++ b/pkg/components/nodeobservabilityoperator/component.go
@@ -3,7 +3,6 @@ package nodeobservabilityoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/nodetuningoperator/component.go
+++ b/pkg/components/nodetuningoperator/component.go
@@ -3,7 +3,6 @@ package nodetuningoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -42,7 +41,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/none/component.go
+++ b/pkg/components/none/component.go
@@ -3,7 +3,6 @@ package none
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/oauthapiserver/component.go
+++ b/pkg/components/oauthapiserver/component.go
@@ -3,7 +3,6 @@ package oauthapiserver
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -48,7 +47,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/oauthproxy/component.go
+++ b/pkg/components/oauthproxy/component.go
@@ -3,7 +3,6 @@ package oauthproxy
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -42,7 +41,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/observabilityui/component.go
+++ b/pkg/components/observabilityui/component.go
@@ -3,7 +3,6 @@ package observabilityui
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/oc/component.go
+++ b/pkg/components/oc/component.go
@@ -3,7 +3,6 @@ package oc
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -42,7 +41,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/oc/ocmirror/component.go
+++ b/pkg/components/oc/ocmirror/component.go
@@ -3,7 +3,6 @@ package ococmirror
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/occompliance/component.go
+++ b/pkg/components/occompliance/component.go
@@ -3,7 +3,6 @@ package occompliance
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/olm/component.go
+++ b/pkg/components/olm/component.go
@@ -3,7 +3,6 @@ package olm
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -48,7 +47,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/olm/operatorhub/component.go
+++ b/pkg/components/olm/operatorhub/component.go
@@ -3,7 +3,6 @@ package olmoperatorhub
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/olm/registry/component.go
+++ b/pkg/components/olm/registry/component.go
@@ -3,7 +3,6 @@ package olmregistry
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/openshiftapiserver/component.go
+++ b/pkg/components/openshiftapiserver/component.go
@@ -3,7 +3,6 @@ package openshiftapiserver
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -45,7 +44,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/openshiftcontrollermanager/apps/component.go
+++ b/pkg/components/openshiftcontrollermanager/apps/component.go
@@ -3,7 +3,6 @@ package openshiftcontrollermanagerapps
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -42,7 +41,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/openshiftcontrollermanager/build/component.go
+++ b/pkg/components/openshiftcontrollermanager/build/component.go
@@ -3,7 +3,6 @@ package openshiftcontrollermanagerbuild
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/openshiftcontrollermanager/controllermanager/component.go
+++ b/pkg/components/openshiftcontrollermanager/controllermanager/component.go
@@ -3,7 +3,6 @@ package openshiftcontrollermanagercontrollermanager
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -42,7 +41,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/openshiftupdateservice/operand/component.go
+++ b/pkg/components/openshiftupdateservice/operand/component.go
@@ -3,7 +3,6 @@ package openshiftupdateserviceoperand
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/openshiftupdateservice/operator/component.go
+++ b/pkg/components/openshiftupdateservice/operator/component.go
@@ -3,7 +3,6 @@ package openshiftupdateserviceoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/operatorsdk/component.go
+++ b/pkg/components/operatorsdk/component.go
@@ -3,7 +3,6 @@ package operatorsdk
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/performanceaddonoperator/component.go
+++ b/pkg/components/performanceaddonoperator/component.go
@@ -3,7 +3,6 @@ package performanceaddonoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/poisonpilloperator/component.go
+++ b/pkg/components/poisonpilloperator/component.go
@@ -3,7 +3,6 @@ package poisonpilloperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/registryconsole/component.go
+++ b/pkg/components/registryconsole/component.go
@@ -3,7 +3,6 @@ package registryconsole
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/release/component.go
+++ b/pkg/components/release/component.go
@@ -3,7 +3,6 @@ package release
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/rhcos/component.go
+++ b/pkg/components/rhcos/component.go
@@ -3,7 +3,6 @@ package rhcos
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -42,7 +41,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/rhmimonitoring/component.go
+++ b/pkg/components/rhmimonitoring/component.go
@@ -3,7 +3,6 @@ package rhmimonitoring
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/routecontrollermanager/component.go
+++ b/pkg/components/routecontrollermanager/component.go
@@ -3,7 +3,6 @@ package routecontrollermanager
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/runoncedurationoverride/component.go
+++ b/pkg/components/runoncedurationoverride/component.go
@@ -3,7 +3,6 @@ package runoncedurationoverride
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/samplesoperator/component.go
+++ b/pkg/components/samplesoperator/component.go
@@ -3,7 +3,6 @@ package samplesoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -45,7 +44,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/sandboxedcontainers/component.go
+++ b/pkg/components/sandboxedcontainers/component.go
@@ -3,7 +3,6 @@ package sandboxedcontainers
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/secondaryscheduleroperator/component.go
+++ b/pkg/components/secondaryscheduleroperator/component.go
@@ -3,7 +3,6 @@ package secondaryscheduleroperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/security/component.go
+++ b/pkg/components/security/component.go
@@ -3,7 +3,6 @@ package security
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/securityprofilesoperator/component.go
+++ b/pkg/components/securityprofilesoperator/component.go
@@ -3,7 +3,6 @@ package securityprofilesoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/servicebinding/component.go
+++ b/pkg/components/servicebinding/component.go
@@ -3,7 +3,6 @@ package servicebinding
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/servicebroker/component.go
+++ b/pkg/components/servicebroker/component.go
@@ -3,7 +3,6 @@ package servicebroker
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/serviceca/component.go
+++ b/pkg/components/serviceca/component.go
@@ -3,7 +3,6 @@ package serviceca
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -42,7 +41,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/servicecatalog/component.go
+++ b/pkg/components/servicecatalog/component.go
@@ -3,7 +3,6 @@ package servicecatalog
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -45,7 +44,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/specialresourceoperator/component.go
+++ b/pkg/components/specialresourceoperator/component.go
@@ -3,7 +3,6 @@ package specialresourceoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/storage/component.go
+++ b/pkg/components/storage/component.go
@@ -3,7 +3,6 @@ package storage
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -48,7 +47,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/storage/kubernetes/component.go
+++ b/pkg/components/storage/kubernetes/component.go
@@ -3,7 +3,6 @@ package storagekubernetes
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/storage/kubernetesexternalcomponents/component.go
+++ b/pkg/components/storage/kubernetesexternalcomponents/component.go
@@ -3,7 +3,6 @@ package storagekubernetesexternalcomponents
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -42,7 +41,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/storage/localstorageoperator/component.go
+++ b/pkg/components/storage/localstorageoperator/component.go
@@ -3,7 +3,6 @@ package storagelocalstorageoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/storage/openstackcsidrivers/component.go
+++ b/pkg/components/storage/openstackcsidrivers/component.go
@@ -3,7 +3,6 @@ package storageopenstackcsidrivers
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/storage/operators/component.go
+++ b/pkg/components/storage/operators/component.go
@@ -3,7 +3,6 @@ package storageoperators
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/storage/ovirtcsidriver/component.go
+++ b/pkg/components/storage/ovirtcsidriver/component.go
@@ -3,7 +3,6 @@ package storageovirtcsidriver
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/storage/sharedresourcecsidriver/component.go
+++ b/pkg/components/storage/sharedresourcecsidriver/component.go
@@ -3,7 +3,6 @@ package storagesharedresourcecsidriver
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/telcoedge/hweventoperator/component.go
+++ b/pkg/components/telcoedge/hweventoperator/component.go
@@ -3,7 +3,6 @@ package telcoedgehweventoperator
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/telcoedge/ran/component.go
+++ b/pkg/components/telcoedge/ran/component.go
@@ -3,7 +3,6 @@ package telcoedgeran
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/telcoedge/talo/component.go
+++ b/pkg/components/telcoedge/talo/component.go
@@ -3,7 +3,6 @@ package telcoedgetalo
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/telcoedge/ztp/component.go
+++ b/pkg/components/telcoedge/ztp/component.go
@@ -3,7 +3,6 @@ package telcoedgeztp
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/telemeter/component.go
+++ b/pkg/components/telemeter/component.go
@@ -3,7 +3,6 @@ package telemeter
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/templates/component.go
+++ b/pkg/components/templates/component.go
@@ -3,7 +3,6 @@ package templates
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/testframework/component.go
+++ b/pkg/components/testframework/component.go
@@ -3,7 +3,6 @@ package testframework
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -72,7 +71,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/testframework/openstack/component.go
+++ b/pkg/components/testframework/openstack/component.go
@@ -3,7 +3,6 @@ package testframeworkopenstack
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/testinfrastructure/component.go
+++ b/pkg/components/testinfrastructure/component.go
@@ -3,7 +3,6 @@ package testinfrastructure
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/topolvm/component.go
+++ b/pkg/components/topolvm/component.go
@@ -3,7 +3,6 @@ package topolvm
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/unknown/component.go
+++ b/pkg/components/unknown/component.go
@@ -3,7 +3,6 @@ package unknown
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/virtualization/component.go
+++ b/pkg/components/virtualization/component.go
@@ -3,7 +3,6 @@ package virtualization
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/components/windowscontainers/component.go
+++ b/pkg/components/windowscontainers/component.go
@@ -3,7 +3,6 @@ package windowscontainers
 import (
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
-	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 type Component struct {
@@ -38,7 +37,7 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	return util.StableID(test)
+	return test.Name
 }
 
 func (c *Component) JiraComponents() (components []string) {

--- a/pkg/util/tests.go
+++ b/pkg/util/tests.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"crypto/md5"
 	"fmt"
 	"regexp"
 	"strings"
@@ -23,13 +24,12 @@ func ExtractTestField(testName, field string) (results []string) {
 	return results
 }
 
-// StableID produces a stable test ID based on a TestInfo struct.
-func StableID(testInfo *v1.TestInfo) string {
-	testName := testInfo.Name
-
+// StableID produces a stable test ID based on a TestInfo struct and a stableName.
+func StableID(testInfo *v1.TestInfo, stableName string) string {
+	hash := fmt.Sprintf("%x", md5.Sum([]byte(stableName)))
 	if testInfo.Suite != "" {
-		return fmt.Sprintf("%s.%s", testInfo.Suite, testName)
+		stableName = fmt.Sprintf("%s:%s", testInfo.Suite, hash)
 	}
 
-	return testName
+	return stableName
 }


### PR DESCRIPTION
Justin's POC uses "suite:md5" for the test ID, which I think is more useful to find the stable named tests irrespective of suite. This also removes the requirement for components to construct the "suite:name" format when renaming tests.

Before:
`"ID": "513de1d82949b140662af430027061a6"`

Now:
`"ID": "openshift-tests-upgrade:8fbe78a6c0ac5ac55e3b616b6e6fd6e7"`
