### PR TITLE
Verify that test ownership doesn't go assigned to "Unknown"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ test:
 
 mapping: build
 	./ci-test-mapping map --mode=local
+	./ci-test-mapping map-verify
 
 unmapped:
 	jq '.[] | select(.Component == "Unknown") | .Name' mapping.json | sort | uniq

--- a/cmd/ci-test-mapping/jira_create.go
+++ b/cmd/ci-test-mapping/jira_create.go
@@ -30,7 +30,7 @@ func NewCreateFlags() *CreateFlags {
 }
 
 var createCmd = &cobra.Command{
-	Use:   "create",
+	Use:   "jira-create",
 	Short: "Create mapping components for missing Jira components",
 	Run: func(cmd *cobra.Command, args []string) {
 		f := NewCreateFlags()

--- a/cmd/ci-test-mapping/jira_verify.go
+++ b/cmd/ci-test-mapping/jira_verify.go
@@ -21,7 +21,7 @@ func NewVerifyFlags() *VerifyFlags {
 }
 
 var verifyCmd = &cobra.Command{
-	Use:   "verify",
+	Use:   "jira-verify",
 	Short: "Verify all JIRA components are represented in ci-test-mapping",
 	Run: func(cmd *cobra.Command, args []string) {
 		f := NewVerifyFlags()

--- a/cmd/ci-test-mapping/mapping_verify.go
+++ b/cmd/ci-test-mapping/mapping_verify.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
+	"github.com/openshift-eng/ci-test-mapping/pkg/components"
+)
+
+type VerifyMapFlags struct {
+	CurrentMapURL string
+	NewMapFile    string
+}
+
+func NewVerifyMapFlags() *VerifyMapFlags {
+	return &VerifyMapFlags{
+		CurrentMapURL: "https://raw.githubusercontent.com/openshift-eng/ci-test-mapping/main/mapping.json",
+		NewMapFile:    "mapping.json",
+	}
+}
+
+var verifyMapCmd = &cobra.Command{
+	Use:   "map-verify",
+	Short: "Verify mapping is correct, i.e. no tests are moving from assigned to unknown",
+	Run: func(cmd *cobra.Command, args []string) {
+		f := NewVerifyMapFlags()
+
+		now := time.Now()
+		logrus.Infof("verifying mappings are correct...")
+
+		// **** Get the current mappings
+		response, err := http.Get(f.CurrentMapURL)
+		if err != nil {
+			fmt.Println("Failed to fetch data:", err)
+			return
+		}
+		defer response.Body.Close()
+		currentMap, err := fetchMap(response.Body)
+		if err != nil {
+			logrus.WithError(err).Fatalf("couldn't fetch current mapping")
+		}
+
+		// Create current mapping lookup table
+		type cl struct {
+			name  string
+			suite string
+		}
+		currentComponents := make(map[cl]string)
+		for _, mapping := range currentMap {
+			currentComponents[cl{mapping.Name, mapping.Suite}] = mapping.Component
+		}
+
+		// **** Get the mappings from the file
+		file, err := os.Open(f.NewMapFile)
+		if err != nil {
+			fmt.Println("Failed to open file:", err)
+			return
+		}
+		defer file.Close()
+		newMap, err := fetchMap(file)
+		if err != nil {
+			logrus.WithError(err).Fatalf("couldn't read new mapping from file")
+		}
+
+		// Look for removed mappings
+		removedMaps := make([]cl, 0)
+		for _, n := range newMap {
+			if n.Component == components.DefaultComponent {
+				locator := cl{n.Name, n.Suite}
+				if old, ok := currentComponents[locator]; ok && old != components.DefaultComponent {
+					removedMaps = append(removedMaps, locator)
+				}
+			}
+		}
+
+		logrus.Infof("verification complete in %+v", time.Since(now))
+		if len(removedMaps) > 0 {
+			for _, removed := range removedMaps {
+				logrus.WithFields(logrus.Fields{
+					"Name":  removed.name,
+					"Suite": removed.suite,
+				}).Warningf("test moved from %q to \"Unknown\"", currentComponents[removed])
+			}
+			logrus.Fatalf("Components are not allowed to move to Unknown. Please assign correct ownership.")
+		}
+	},
+}
+
+func fetchMap(f io.Reader) ([]v1.TestOwnership, error) {
+	body, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var mapping []v1.TestOwnership
+	err = json.Unmarshal(body, &mapping)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	return mapping, nil
+}
+
+func init() {
+	rootCmd.AddCommand(verifyMapCmd)
+}

--- a/cmd/ci-test-mapping/mapping_verify.go
+++ b/cmd/ci-test-mapping/mapping_verify.go
@@ -73,24 +73,27 @@ var verifyMapCmd = &cobra.Command{
 		// Look for removed mappings
 		removedMaps := make([]cl, 0)
 		for _, n := range newMap {
-			if n.Component == components.DefaultComponent {
-				locator := cl{n.Name, n.Suite}
-				if old, ok := currentComponents[locator]; ok && old != components.DefaultComponent {
-					removedMaps = append(removedMaps, locator)
-				}
+			if n.Component != components.DefaultComponent {
+				continue
+			}
+			locator := cl{n.Name, n.Suite}
+			if old, ok := currentComponents[locator]; ok && old != components.DefaultComponent {
+				removedMaps = append(removedMaps, locator)
 			}
 		}
 
 		logrus.Infof("verification complete in %+v", time.Since(now))
-		if len(removedMaps) > 0 {
-			for _, removed := range removedMaps {
-				logrus.WithFields(logrus.Fields{
-					"Name":  removed.name,
-					"Suite": removed.suite,
-				}).Warningf("test moved from %q to \"Unknown\"", currentComponents[removed])
-			}
-			logrus.Fatalf("Components are not allowed to move to Unknown. Please assign correct ownership.")
+		if len(removedMaps) == 0 {
+			return
 		}
+
+		for _, removed := range removedMaps {
+			logrus.WithFields(logrus.Fields{
+				"Name":  removed.name,
+				"Suite": removed.suite,
+			}).Warningf("test moved from %q to \"Unknown\"", currentComponents[removed])
+		}
+		logrus.Fatalf("Components are not allowed to move to Unknown. Please assign correct ownership.")
 	},
 }
 


### PR DESCRIPTION
will error out in CI like this:

```
time="2023-05-24T17:30:45Z" level=warning msg="test moved from \"Etcd\" to \"Unknown\"" Name="[sig-etcd][Serial] etcd [apigroup:config.openshift.io] is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io] [Suite:openshift/conformance/serial]" Suite=openshift-tests
time="2023-05-24T17:30:45Z" level=fatal msg="Components are not allowed to move to Unknown. Please assign correct ownership." 
```

Example failure: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift-eng_ci-test-mapping/19/pull-ci-openshift-eng-ci-test-mapping-main-mapping/1661423377182625792