### PR TITLE
Fix bug in mapping of unknown test names

### DIFF
--- a/pkg/components/component.go
+++ b/pkg/components/component.go
@@ -37,7 +37,7 @@ func IdentifyTest(reg *registry.Registry, test *v1.TestInfo) (*v1.TestOwnership,
 
 	if len(ownerships) == 0 {
 		ownerships = append(ownerships, setDefaults(test, &v1.TestOwnership{
-			ID:   util.StableID(test, util.StableID(test, test.Name)),
+			ID:   util.StableID(test, test.Name),
 			Name: test.Name,
 		}, nil))
 	}


### PR DESCRIPTION
util.StableID was wraped by itself, giving the wrong ID for unknown tests.