### PR TITLE
TRT-9999: Revert #57 "Add support for matching Jira component from test name"

### DIFF
--- a/pkg/config/component.go
+++ b/pkg/config/component.go
@@ -2,13 +2,11 @@ package config
 
 import (
 	"regexp"
-	"strconv"
 	"strings"
-
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // Component is the default configuration struct that you can include in your
@@ -48,20 +46,6 @@ type ComponentMatcher struct {
 }
 
 func (c *Component) FindMatch(test *v1.TestInfo) *ComponentMatcher {
-	jiraComponents := util.ExtractTestField(test.Name, "Jira")
-	for _, jc := range jiraComponents {
-		unquoted, err := strconv.Unquote(jc)
-		if err != nil { // not quoted
-			unquoted = jc
-		}
-
-		if strings.EqualFold(unquoted, c.DefaultJiraComponent) {
-			return &ComponentMatcher{
-				JiraComponent: c.DefaultJiraComponent,
-			}
-		}
-	}
-
 	if ok, capabilities := c.IsOperatorTest(test); ok {
 		return &ComponentMatcher{
 			JiraComponent: c.DefaultJiraComponent,


### PR DESCRIPTION

Reverts #57 ; tracked by TRT-9999

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

This PR broke all CI, see this job for details: http://prow/whatever/job/123481234

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload 4.14 nightly blocking
```

CC: @stbenjam

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
