### PR TITLE
Add jira component ID's to ci-test-mapping

### DIFF
--- a/pkg/api/types/v1/component.go
+++ b/pkg/api/types/v1/component.go
@@ -89,6 +89,9 @@ type TestOwnership struct {
 	// JIRAComponent specifies the JIRA component that this test belongs to.
 	JIRAComponent string `bigquery:"jira_component"`
 
+	// JIRAComponentID specifies the ID of the JIRA component above.
+	JIRAComponentID *uint `bigquery:"jira_component_id"`
+
 	// CreatedAt is the time this particular record was created.
 	//
 	// Components do not need to set this value.

--- a/pkg/api/types/v1/jira.go
+++ b/pkg/api/types/v1/jira.go
@@ -1,0 +1,27 @@
+package v1
+
+type JiraUser struct {
+	Self        string `json:"self"`
+	Name        string `json:"name"`
+	Key         string `json:"key"`
+	DisplayName string `json:"displayName"`
+	Active      bool   `json:"active"`
+	TimeZone    string `json:"timeZone"`
+}
+
+type JiraComponent struct {
+	Self                string   `json:"self"`
+	ID                  string   `json:"id"`
+	Name                string   `json:"name"`
+	Description         string   `json:"description"`
+	Lead                JiraUser `json:"lead"`
+	AssigneeType        string   `json:"assigneeType"`
+	Assignee            JiraUser `json:"assignee"`
+	RealAssigneeType    string   `json:"realAssigneeType"`
+	RealAssignee        JiraUser `json:"realAssignee"`
+	IsAssigneeTypeValid bool     `json:"isAssigneeTypeValid"`
+	Project             string   `json:"project"`
+	ProjectID           int      `json:"projectId"`
+	Archived            bool     `json:"archived"`
+	Deleted             bool     `json:"deleted"`
+}

--- a/pkg/components/component.go
+++ b/pkg/components/component.go
@@ -18,11 +18,27 @@ const (
 	DefaultProduct    = "OpenShift"
 )
 
-func IdentifyTest(reg *registry.Registry, test *v1.TestInfo) (*v1.TestOwnership, error) {
+type TestIdentifier struct {
+	reg          *registry.Registry
+	componentIDs map[string]uint
+}
+
+func New(reg *registry.Registry, componentIDs map[string]uint) *TestIdentifier {
+	if componentIDs == nil {
+		componentIDs = make(map[string]uint)
+	}
+
+	return &TestIdentifier{
+		reg:          reg,
+		componentIDs: componentIDs,
+	}
+}
+
+func (t *TestIdentifier) Identify(test *v1.TestInfo) (*v1.TestOwnership, error) {
 	var ownerships []*v1.TestOwnership
 
-	log.WithFields(testInfoLogFields(test)).Debugf("attempting to identify test using %d components", len(reg.Components))
-	for name, component := range reg.Components {
+	log.WithFields(testInfoLogFields(test)).Debugf("attempting to identify test using %d components", len(t.reg.Components))
+	for name, component := range t.reg.Components {
 		log.WithFields(testInfoLogFields(test)).Tracef("checking component %q", name)
 		ownership, err := component.IdentifyTest(test)
 		if err != nil {
@@ -31,12 +47,12 @@ func IdentifyTest(reg *registry.Registry, test *v1.TestInfo) (*v1.TestOwnership,
 		}
 		if ownership != nil {
 			log.WithFields(testInfoLogFields(test)).Tracef("component %q claimed this test", name)
-			ownerships = append(ownerships, setDefaults(test, ownership, component))
+			ownerships = append(ownerships, t.setDefaults(test, ownership, component))
 		}
 	}
 
 	if len(ownerships) == 0 {
-		ownerships = append(ownerships, setDefaults(test, &v1.TestOwnership{
+		ownerships = append(ownerships, t.setDefaults(test, &v1.TestOwnership{
 			ID:   util.StableID(test, test.Name),
 			Name: test.Name,
 		}, nil))
@@ -53,7 +69,7 @@ func IdentifyTest(reg *registry.Registry, test *v1.TestInfo) (*v1.TestOwnership,
 	return highestPriority, nil
 }
 
-func setDefaults(testInfo *v1.TestInfo, testOwnership *v1.TestOwnership, c v1.Component) *v1.TestOwnership {
+func (t *TestIdentifier) setDefaults(testInfo *v1.TestInfo, testOwnership *v1.TestOwnership, c v1.Component) *v1.TestOwnership {
 	if testOwnership.ID == "" && c != nil {
 		testOwnership.ID = util.StableID(testInfo, c.StableID(testInfo))
 	}
@@ -67,7 +83,14 @@ func setDefaults(testInfo *v1.TestInfo, testOwnership *v1.TestOwnership, c v1.Co
 
 	if testOwnership.Component == "" {
 		testOwnership.Component = DefaultComponent
+	}
+
+	if testOwnership.JIRAComponent == "" {
 		testOwnership.JIRAComponent = DefaultComponent
+	}
+
+	if id, ok := t.componentIDs[testOwnership.JIRAComponent]; ok {
+		testOwnership.JIRAComponentID = &id
 	}
 
 	if len(testOwnership.Capabilities) == 0 {

--- a/pkg/components/component_test.go
+++ b/pkg/components/component_test.go
@@ -50,6 +50,7 @@ func TestIdentifyTest(t *testing.T) {
 			},
 		},
 	}
+	ti := New(componentRegistry, nil)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.before != nil {
@@ -58,7 +59,7 @@ func TestIdentifyTest(t *testing.T) {
 				}
 			}
 
-			testOwnership, err := IdentifyTest(componentRegistry, tt.testInfo)
+			testOwnership, err := ti.Identify(tt.testInfo)
 			if tt.wantError == "" && err != nil {
 				t.Fatalf("IdentifyTest() returned unexpected err: %+v", err)
 			} else if tt.wantError != "" && err == nil {

--- a/pkg/jira/ocpbugs.go
+++ b/pkg/jira/ocpbugs.go
@@ -1,0 +1,75 @@
+package jira
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
+)
+
+func GetJiraComponents() (map[string]uint, error) {
+	start := time.Now()
+	log.Infof("loading jira ocpbugs component information...")
+	body, err := jiraRequest("https://issues.redhat.com/rest/api/2/project/12332330/components")
+	if err != nil {
+		return nil, err
+	}
+
+	var components []v1.JiraComponent
+	err = json.Unmarshal(body, &components)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make(map[string]uint)
+	for _, c := range components {
+		jiraID, err := strconv.ParseUint(c.ID, 10, 64)
+		if err != nil {
+			msg := "error parsing jira ID"
+			log.WithError(err).Warn(msg)
+		}
+
+		ids[c.Name] = uint(jiraID)
+	}
+
+	log.Infof("jira ocpbugs components loaded in %+v", time.Since(start))
+	return ids, nil
+}
+
+func jiraRequest(apiURL string) ([]byte, error) {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// For a fresh sync to a developer DB, no jira token is needed since the issues API is still open. However, if
+	// we need to find cards where the trt-incident label was removed this API is not protected and returns 401
+	// if tried unauthed.  So really this only affects long-lived instances of Sippy.
+	//
+	// WARNING: DO NOT give public-facing Sippy a personal developer token, use a service account that is not marked
+	// as a Red Hat employee.
+	token := os.Getenv("JIRA_TOKEN")
+	if token == "" {
+		log.Warningf("no token, proceeding unauthenticated (ok for most queries)")
+	} else {
+		req.Header.Add("Authorization", "Bearer "+token)
+	}
+
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return io.ReadAll(resp.Body)
+}


### PR DESCRIPTION
In order to automate any jira creation (i.e. via links from component readiness), we need to have the component ID from JIRA. This adds that data to the ci-test-mapping table.