### PR TITLE
Fix a bug in bigquery NullInt64

### DIFF
--- a/pkg/components/component.go
+++ b/pkg/components/component.go
@@ -93,6 +93,7 @@ func (t *TestIdentifier) setDefaults(testInfo *v1.TestInfo, testOwnership *v1.Te
 	if id, ok := t.componentIDs[testOwnership.JIRAComponent]; ok {
 		testOwnership.JIRAComponentID = bigquery.NullInt64{
 			Int64: id,
+			Valid: true,
 		}
 	}
 


### PR DESCRIPTION
BigQuery type requires `Valid: true` for NullInt64 to work.