### PR TITLE
use include any

### DIFF
--- a/pkg/components/kubeapiserver/component.go
+++ b/pkg/components/kubeapiserver/component.go
@@ -25,16 +25,14 @@ var KubeApiserverComponent = Component{
 		},
 		Matchers: []config.ComponentMatcher{
 			{
-				IncludeAll: []string{"bz-kube-apiserver"},
-			},
-			{
-				IncludeAll: []string{"cache-kube-api-"},
+				IncludeAny: []string{
+					"bz-kube-apiserver",
+					"cache-kube-api-",
+					"[sig-api-machinery][Feature:APIServer]",
+				},
 			},
 			{
 				IncludeAll: []string{"kube-api-", "-connections"},
-			},
-			{
-				IncludeAll: []string{"[sig-api-machinery][Feature:APIServer]"},
 			},
 			{
 				SIG:      "sig-api-machinery",

--- a/pkg/components/networking/router/component.go
+++ b/pkg/components/networking/router/component.go
@@ -21,9 +21,6 @@ var RouterComponent = Component{
 		},
 		Matchers: []config.ComponentMatcher{
 			{
-				IncludeAll: []string{"bz-Routing"},
-			},
-			{
 				SIG:        "sig-network",
 				IncludeAll: []string{"Feature:Router"},
 			},
@@ -35,17 +32,11 @@ var RouterComponent = Component{
 				IncludeAll: []string{"ingress-to-", "disruption"},
 			},
 			{
-				IncludeAll: []string{"openshift-ingress"},
-			},
-			{
-				IncludeAll: []string{"via cluster ingress"},
-			},
-			{
-				IncludeAll: []string{"Cluster frontend ingress"},
-			},
-			{
 				IncludeAny: []string{
-					"[sig-arch] Managed cluster should [apigroup:apps.openshift.io] should expose cluster services outside the cluster [apigroup:route.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+					"bz-Routing",
+					"openshift-ingress",
+					"via cluster ingress",
+					"Cluster frontend ingress", "[sig-arch] Managed cluster should [apigroup:apps.openshift.io] should expose cluster services outside the cluster [apigroup:route.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 					"[sig-arch] Managed cluster should expose cluster services outside the cluster [apigroup:route.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 					"[sig-network-edge][Feature:Idling] Idling with a single service and ReplicationController should idle the service and ReplicationController properly [Suite:openshift/conformance/parallel]",
 					"[sig-network-edge][Feature:Idling] Unidling [apigroup:apps.openshift.io][apigroup:route.openshift.io] should handle many TCP connections by possibly dropping those over a certain bound [Serial] [Skipped:Network/OVNKubernetes] [Suite:openshift/conformance/serial]",


### PR DESCRIPTION
minor cleanup as I was chasing unknown components.  Tightens up expression and does not change mapping results.