### PR TITLE
Add mechanism for marking tests obsolete

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,20 @@
+aliases:
+   openshift-staff-engineers:
+    - aravindhp
+    - bparees
+    - deads2k
+    - dhellmann
+    - jerpeter1
+    - joelanford
+    - jupierce
+    - knobunc
+    - ncdc
+    - Prashanth684
+    - sdodson
+    - soltysh
+    - zaneb
+ # commented members need to join openshift-eng org
+ #   - derekwaynecarr
+ #   - jhjaggars
+ #   - mrunalp
+ #   - stleerh

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ responsible for ensuring the `StableID` function in their component
 returns the same ID for all names of a given test. This can be done with
 a simple look-up map, see the monitoring component for an example.
 
+## Removing tests
+
+If a test is removed, or is refactored in such a way (i.e. one to many)
+that it's not reasonable to mark them as renames, then it should be
+tracked as an obsolete test. In `pkg/obsoletetests` one can manage their
+obsolete tests by adding an entry to the set.  For OCP, only staff
+engineers can approve a test's removal.
+
 # Test Sources
 
 Currently the tests we use for mapping comes from the corpus of tests

--- a/cmd/ci-test-mapping/map.go
+++ b/cmd/ci-test-mapping/map.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift-eng/ci-test-mapping/pkg/bigquery"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components"
 	"github.com/openshift-eng/ci-test-mapping/pkg/jira"
+	"github.com/openshift-eng/ci-test-mapping/pkg/obsoletetests"
 	"github.com/openshift-eng/ci-test-mapping/pkg/registry"
 )
 
@@ -79,7 +80,7 @@ var mapCmd = &cobra.Command{
 		if err != nil {
 			log.WithError(err).Fatalf("could not get jira component mapping")
 		}
-
+		testObsoleter := &obsoletetests.OCPObsoleteTestManager{}
 		testIdentifier := components.New(componentRegistry, jiraComponentIDs)
 		var newMappings []v1.TestOwnership
 		var matched, unmatched int
@@ -95,6 +96,8 @@ var mapCmd = &cobra.Command{
 					matched++
 				}
 				ownership.CreatedAt = createdAt
+
+				ownership.StaffApprovedObsolete = testObsoleter.IsObsolete(&tests[i])
 				newMappings = append(newMappings, *ownership)
 			}
 		}

--- a/pkg/obsoletetests/OWNERS
+++ b/pkg/obsoletetests/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - openshift-staff-engineers
+reviewers:
+  - openshift-staff-engineers
+options:
+  no_parent_owners: true

--- a/pkg/obsoletetests/obsoletetests.go
+++ b/pkg/obsoletetests/obsoletetests.go
@@ -1,0 +1,7 @@
+package obsoletetests
+
+import v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
+
+type ObsoleteTestManager interface {
+	IsObsolete(*v1.TestInfo) bool
+}

--- a/pkg/obsoletetests/ocp_obsoletetests.go
+++ b/pkg/obsoletetests/ocp_obsoletetests.go
@@ -1,0 +1,27 @@
+package obsoletetests
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
+)
+
+type OCPObsoleteTestManager struct{}
+
+type obsoleteTestIdentifier struct {
+	name  string
+	suite string
+}
+
+var obsoleteTests = sets.New[obsoleteTestIdentifier](
+	[]obsoleteTestIdentifier{
+		// Removed in alert refactor by TRT https://github.com/openshift/origin/pull/28332
+		{
+			name:  "[sig-arch] Check if alerts are firing during or after upgrade success",
+			suite: "Cluster upgrade",
+		},
+	}...)
+
+func (*OCPObsoleteTestManager) IsObsolete(test *v1.TestInfo) bool {
+	return obsoleteTests.Has(obsoleteTestIdentifier{name: test.Name, suite: test.Suite})
+}


### PR DESCRIPTION
[TRT-1410](https://issues.redhat.com//browse/TRT-1410)

This implements the previously planned but unimplemented feature "StaffApprovedObsolete" which will make that test be excluded from component readiness.

When a test is removed from OpenShift with no equivalent to map a rename to, we end up reporting that the test is missing from the sample data.

Goes with https://github.com/openshift/sippy/pull/1371