### PR TITLE
Rename: typo in network monitor tests, avalibility to availability

### DIFF
--- a/pkg/components/networking/ovnkubernetes/component.go
+++ b/pkg/components/networking/ovnkubernetes/component.go
@@ -1,12 +1,23 @@
 package networkingovnkubernetes
 
 import (
+	"regexp"
+
+	log "github.com/sirupsen/logrus"
+
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
 )
 
+// A regular expression + its replacement string to apply to test names
+type testNameReplacement struct {
+	regexp      *regexp.Regexp
+	replacement string
+}
+
 type Component struct {
 	*config.Component
+	testNameReplacements []testNameReplacement
 }
 
 var OvnKubernetesComponent = Component{
@@ -34,6 +45,12 @@ var OvnKubernetesComponent = Component{
 			"[Networking][invariant] alert/KubePodNotReady should not be at or above pending in ns/openshift-ovn-kubernetes": "[bz-Networking][invariant] alert/KubePodNotReady should not be at or above pending in ns/openshift-ovn-kubernetes",
 		},
 	},
+	testNameReplacements: []testNameReplacement{
+		{
+			regexp:      regexp.MustCompile("avalibility"),
+			replacement: "availability",
+		},
+	},
 }
 
 func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
@@ -55,11 +72,20 @@ func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
 }
 
 func (c *Component) StableID(test *v1.TestInfo) string {
-	// Look up the stable name for our test in our renamed tests map.
-	if stableName, ok := c.TestRenames[test.Name]; ok {
-		return stableName
+	// Apply any test name replacements
+	name := test.Name
+	for _, r := range c.testNameReplacements {
+		name = r.regexp.ReplaceAllString(name, r.replacement)
 	}
-	return test.Name
+
+	// Look up the stable name for our test in our renamed tests map.
+	if stableName, ok := c.TestRenames[name]; ok {
+		name = stableName
+	}
+	if name != test.Name {
+		log.Tracef("Mapped test %q to %q", test.Name, name)
+	}
+	return name
 }
 
 func (c *Component) JiraComponents() (components []string) {


### PR DESCRIPTION
https://github.com/openshift/origin/pull/28474 fixes the typo in some network monitor test names