### PR TITLE
TRT-1351: Add Disruption capability to disruption tests

### DIFF
--- a/pkg/components/apiserverauth/capabilities.go
+++ b/pkg/components/apiserverauth/capabilities.go
@@ -1,25 +1,12 @@
 package apiserverauth
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/awsloadbalanceroperator/capabilities.go
+++ b/pkg/components/awsloadbalanceroperator/capabilities.go
@@ -1,25 +1,12 @@
 package awsloadbalanceroperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/baremetalhardwareprovisioning/baremetaloperator/capabilities.go
+++ b/pkg/components/baremetalhardwareprovisioning/baremetaloperator/capabilities.go
@@ -1,25 +1,12 @@
 package baremetalhardwareprovisioningbaremetaloperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/baremetalhardwareprovisioning/capabilities.go
+++ b/pkg/components/baremetalhardwareprovisioning/capabilities.go
@@ -1,25 +1,12 @@
 package baremetalhardwareprovisioning
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/baremetalhardwareprovisioning/clusterapiprovider/capabilities.go
+++ b/pkg/components/baremetalhardwareprovisioning/clusterapiprovider/capabilities.go
@@ -1,25 +1,12 @@
 package baremetalhardwareprovisioningclusterapiprovider
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/baremetalhardwareprovisioning/clusterbaremetaloperator/capabilities.go
+++ b/pkg/components/baremetalhardwareprovisioning/clusterbaremetaloperator/capabilities.go
@@ -1,25 +1,12 @@
 package baremetalhardwareprovisioningclusterbaremetaloperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/baremetalhardwareprovisioning/ironic/capabilities.go
+++ b/pkg/components/baremetalhardwareprovisioning/ironic/capabilities.go
@@ -1,25 +1,12 @@
 package baremetalhardwareprovisioningironic
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/baremetalhardwareprovisioning/osimageprovider/capabilities.go
+++ b/pkg/components/baremetalhardwareprovisioning/osimageprovider/capabilities.go
@@ -1,25 +1,12 @@
 package baremetalhardwareprovisioningosimageprovider
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/build/capabilities.go
+++ b/pkg/components/build/capabilities.go
@@ -1,25 +1,12 @@
 package build
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/certmanager/capabilities.go
+++ b/pkg/components/certmanager/capabilities.go
@@ -1,25 +1,12 @@
 package certmanager
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/cloudcompute/baremetalprovider/capabilities.go
+++ b/pkg/components/cloudcompute/baremetalprovider/capabilities.go
@@ -1,25 +1,12 @@
 package cloudcomputebaremetalprovider
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/cloudcompute/cloudcontrollermanager/capabilities.go
+++ b/pkg/components/cloudcompute/cloudcontrollermanager/capabilities.go
@@ -1,25 +1,12 @@
 package cloudcomputecloudcontrollermanager
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/cloudcompute/clusterautoscaler/capabilities.go
+++ b/pkg/components/cloudcompute/clusterautoscaler/capabilities.go
@@ -1,25 +1,12 @@
 package cloudcomputeclusterautoscaler
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/cloudcompute/externalprovider/capabilities.go
+++ b/pkg/components/cloudcompute/externalprovider/capabilities.go
@@ -1,25 +1,12 @@
 package cloudcomputeexternalprovider
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/cloudcompute/ibmprovider/capabilities.go
+++ b/pkg/components/cloudcompute/ibmprovider/capabilities.go
@@ -1,25 +1,12 @@
 package cloudcomputeibmprovider
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/cloudcompute/kubevirtprovider/capabilities.go
+++ b/pkg/components/cloudcompute/kubevirtprovider/capabilities.go
@@ -1,25 +1,12 @@
 package cloudcomputekubevirtprovider
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/cloudcompute/machinehealthcheck/capabilities.go
+++ b/pkg/components/cloudcompute/machinehealthcheck/capabilities.go
@@ -1,25 +1,12 @@
 package cloudcomputemachinehealthcheck
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/cloudcompute/nutanixprovider/capabilities.go
+++ b/pkg/components/cloudcompute/nutanixprovider/capabilities.go
@@ -1,25 +1,12 @@
 package cloudcomputenutanixprovider
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/cloudcompute/openstackprovider/capabilities.go
+++ b/pkg/components/cloudcompute/openstackprovider/capabilities.go
@@ -1,25 +1,12 @@
 package cloudcomputeopenstackprovider
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/cloudcompute/otherprovider/capabilities.go
+++ b/pkg/components/cloudcompute/otherprovider/capabilities.go
@@ -1,25 +1,12 @@
 package cloudcomputeotherprovider
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/cloudcompute/ovirtprovider/capabilities.go
+++ b/pkg/components/cloudcompute/ovirtprovider/capabilities.go
@@ -1,25 +1,12 @@
 package cloudcomputeovirtprovider
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/cloudcredentialoperator/capabilities.go
+++ b/pkg/components/cloudcredentialoperator/capabilities.go
@@ -1,25 +1,12 @@
 package cloudcredentialoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/cloudnativeevents/cloudeventproxy/capabilities.go
+++ b/pkg/components/cloudnativeevents/cloudeventproxy/capabilities.go
@@ -1,25 +1,12 @@
 package cloudnativeeventscloudeventproxy
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/cloudnativeevents/cloudnativeevents/capabilities.go
+++ b/pkg/components/cloudnativeevents/cloudnativeevents/capabilities.go
@@ -1,25 +1,12 @@
 package cloudnativeeventscloudnativeevents
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/cloudnativeevents/hardwareeventproxy/capabilities.go
+++ b/pkg/components/cloudnativeevents/hardwareeventproxy/capabilities.go
@@ -1,25 +1,12 @@
 package cloudnativeeventshardwareeventproxy
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/clusterloader/capabilities.go
+++ b/pkg/components/clusterloader/capabilities.go
@@ -1,25 +1,12 @@
 package clusterloader
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/clusterresourceoverrideadmissionoperator/capabilities.go
+++ b/pkg/components/clusterresourceoverrideadmissionoperator/capabilities.go
@@ -1,25 +1,12 @@
 package clusterresourceoverrideadmissionoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/clusterversionoperator/capabilities.go
+++ b/pkg/components/clusterversionoperator/capabilities.go
@@ -1,25 +1,12 @@
 package clusterversionoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/cnfcerttnf/capabilities.go
+++ b/pkg/components/cnfcerttnf/capabilities.go
@@ -1,25 +1,12 @@
 package cnfcerttnf
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/cnfplatformvalidation/capabilities.go
+++ b/pkg/components/cnfplatformvalidation/capabilities.go
@@ -1,25 +1,12 @@
 package cnfplatformvalidation
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/complianceoperator/capabilities.go
+++ b/pkg/components/complianceoperator/capabilities.go
@@ -1,25 +1,12 @@
 package complianceoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/configoperator/capabilities.go
+++ b/pkg/components/configoperator/capabilities.go
@@ -1,25 +1,12 @@
 package configoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/consolemetal3plugin/capabilities.go
+++ b/pkg/components/consolemetal3plugin/capabilities.go
@@ -1,25 +1,12 @@
 package consolemetal3plugin
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/consolestorageplugin/capabilities.go
+++ b/pkg/components/consolestorageplugin/capabilities.go
@@ -1,25 +1,12 @@
 package consolestorageplugin
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/containers/capabilities.go
+++ b/pkg/components/containers/capabilities.go
@@ -1,25 +1,12 @@
 package containers
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/crc/capabilities.go
+++ b/pkg/components/crc/capabilities.go
@@ -1,25 +1,12 @@
 package crc
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/descheduler/capabilities.go
+++ b/pkg/components/descheduler/capabilities.go
@@ -1,25 +1,12 @@
 package descheduler
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/devconsole/capabilities.go
+++ b/pkg/components/devconsole/capabilities.go
@@ -1,25 +1,12 @@
 package devconsole
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/drivertoolkit/capabilities.go
+++ b/pkg/components/drivertoolkit/capabilities.go
@@ -1,25 +1,12 @@
 package drivertoolkit
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/etcd/capabilities.go
+++ b/pkg/components/etcd/capabilities.go
@@ -1,25 +1,12 @@
 package etcd
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/example/capabilities.go
+++ b/pkg/components/example/capabilities.go
@@ -1,25 +1,12 @@
 package example
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/externaldnsoperator/capabilities.go
+++ b/pkg/components/externaldnsoperator/capabilities.go
@@ -1,25 +1,12 @@
 package externaldnsoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/fileintegrityoperator/capabilities.go
+++ b/pkg/components/fileintegrityoperator/capabilities.go
@@ -1,25 +1,12 @@
 package fileintegrityoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/hawkular/capabilities.go
+++ b/pkg/components/hawkular/capabilities.go
@@ -1,25 +1,12 @@
 package hawkular
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/helm/capabilities.go
+++ b/pkg/components/helm/capabilities.go
@@ -1,25 +1,12 @@
 package helm
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/hive/capabilities.go
+++ b/pkg/components/hive/capabilities.go
@@ -1,25 +1,12 @@
 package hive
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/hypershift/capabilities.go
+++ b/pkg/components/hypershift/capabilities.go
@@ -1,25 +1,12 @@
 package hypershift
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/ibmrokstoolkit/capabilities.go
+++ b/pkg/components/ibmrokstoolkit/capabilities.go
@@ -1,25 +1,12 @@
 package ibmrokstoolkit
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/imageregistry/capabilities.go
+++ b/pkg/components/imageregistry/capabilities.go
@@ -1,25 +1,12 @@
 package imageregistry
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/imagestreams/capabilities.go
+++ b/pkg/components/imagestreams/capabilities.go
@@ -1,25 +1,12 @@
 package imagestreams
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/insightsoperator/capabilities.go
+++ b/pkg/components/insightsoperator/capabilities.go
@@ -1,25 +1,12 @@
 package insightsoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/installer/agentbasedinstallation/capabilities.go
+++ b/pkg/components/installer/agentbasedinstallation/capabilities.go
@@ -1,25 +1,12 @@
 package installeragentbasedinstallation
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/installer/alibabacloud/capabilities.go
+++ b/pkg/components/installer/alibabacloud/capabilities.go
@@ -1,25 +1,12 @@
 package installeralibabacloud
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/installer/assistedinstaller/capabilities.go
+++ b/pkg/components/installer/assistedinstaller/capabilities.go
@@ -1,25 +1,12 @@
 package installerassistedinstaller
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/installer/ibmcloud/capabilities.go
+++ b/pkg/components/installer/ibmcloud/capabilities.go
@@ -1,25 +1,12 @@
 package installeribmcloud
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/installer/nutanix/capabilities.go
+++ b/pkg/components/installer/nutanix/capabilities.go
@@ -1,25 +1,12 @@
 package installernutanix
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/installer/openshiftansible/capabilities.go
+++ b/pkg/components/installer/openshiftansible/capabilities.go
@@ -1,25 +1,12 @@
 package installeropenshiftansible
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/installer/openshiftinstaller/capabilities.go
+++ b/pkg/components/installer/openshiftinstaller/capabilities.go
@@ -1,25 +1,12 @@
 package installeropenshiftinstaller
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/installer/openshiftonbaremetalipi/capabilities.go
+++ b/pkg/components/installer/openshiftonbaremetalipi/capabilities.go
@@ -1,25 +1,12 @@
 package installeropenshiftonbaremetalipi
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/installer/openshiftonkubevirt/capabilities.go
+++ b/pkg/components/installer/openshiftonkubevirt/capabilities.go
@@ -1,25 +1,12 @@
 package installeropenshiftonkubevirt
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/installer/openshiftonopenstack/capabilities.go
+++ b/pkg/components/installer/openshiftonopenstack/capabilities.go
@@ -1,25 +1,12 @@
 package installeropenshiftonopenstack
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/installer/openshiftonrhv/capabilities.go
+++ b/pkg/components/installer/openshiftonrhv/capabilities.go
@@ -1,25 +1,12 @@
 package installeropenshiftonrhv
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/installer/powervs/capabilities.go
+++ b/pkg/components/installer/powervs/capabilities.go
@@ -1,25 +1,12 @@
 package installerpowervs
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/installer/singlenodeopenshift/capabilities.go
+++ b/pkg/components/installer/singlenodeopenshift/capabilities.go
@@ -1,25 +1,12 @@
 package installersinglenodeopenshift
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/isvoperators/capabilities.go
+++ b/pkg/components/isvoperators/capabilities.go
@@ -1,25 +1,12 @@
 package isvoperators
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/jenkins/capabilities.go
+++ b/pkg/components/jenkins/capabilities.go
@@ -1,25 +1,12 @@
 package jenkins
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/kmm/capabilities.go
+++ b/pkg/components/kmm/capabilities.go
@@ -1,25 +1,12 @@
 package kmm
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/kubeapiserver/capabilities.go
+++ b/pkg/components/kubeapiserver/capabilities.go
@@ -8,18 +8,7 @@ import (
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	if strings.Contains(test.Name, "disruption/") {
 		capabilities = append(capabilities, "Disruption")

--- a/pkg/components/kubecontrollermanager/capabilities.go
+++ b/pkg/components/kubecontrollermanager/capabilities.go
@@ -8,18 +8,7 @@ import (
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	if strings.Contains(test.Name, "ClusterResourceQuota") {
 		capabilities = append(capabilities, "ClusterResourceQuota")

--- a/pkg/components/kubescheduler/capabilities.go
+++ b/pkg/components/kubescheduler/capabilities.go
@@ -1,25 +1,12 @@
 package kubescheduler
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/kubestorageversionmigrator/capabilities.go
+++ b/pkg/components/kubestorageversionmigrator/capabilities.go
@@ -1,25 +1,12 @@
 package kubestorageversionmigrator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/logging/capabilities.go
+++ b/pkg/components/logging/capabilities.go
@@ -1,25 +1,12 @@
 package logging
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/lvms/capabilities.go
+++ b/pkg/components/lvms/capabilities.go
@@ -1,25 +1,12 @@
 package lvms
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/machineconfigoperator/capabilities.go
+++ b/pkg/components/machineconfigoperator/capabilities.go
@@ -1,25 +1,12 @@
 package machineconfigoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/machineconfigoperator/platformbaremetal/capabilities.go
+++ b/pkg/components/machineconfigoperator/platformbaremetal/capabilities.go
@@ -1,25 +1,12 @@
 package machineconfigoperatorplatformbaremetal
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/machineconfigoperator/platformnone/capabilities.go
+++ b/pkg/components/machineconfigoperator/platformnone/capabilities.go
@@ -1,25 +1,12 @@
 package machineconfigoperatorplatformnone
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/machineconfigoperator/platformopenstack/capabilities.go
+++ b/pkg/components/machineconfigoperator/platformopenstack/capabilities.go
@@ -1,25 +1,12 @@
 package machineconfigoperatorplatformopenstack
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/machineconfigoperator/platformovirtrhv/capabilities.go
+++ b/pkg/components/machineconfigoperator/platformovirtrhv/capabilities.go
@@ -1,25 +1,12 @@
 package machineconfigoperatorplatformovirtrhv
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/machineconfigoperator/platformvsphere/capabilities.go
+++ b/pkg/components/machineconfigoperator/platformvsphere/capabilities.go
@@ -1,25 +1,12 @@
 package machineconfigoperatorplatformvsphere
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/managementconsole/capabilities.go
+++ b/pkg/components/managementconsole/capabilities.go
@@ -1,25 +1,12 @@
 package managementconsole
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/meteringoperator/capabilities.go
+++ b/pkg/components/meteringoperator/capabilities.go
@@ -1,25 +1,12 @@
 package meteringoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/microshift/capabilities.go
+++ b/pkg/components/microshift/capabilities.go
@@ -1,25 +1,12 @@
 package microshift
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/microshift/networking/capabilities.go
+++ b/pkg/components/microshift/networking/capabilities.go
@@ -1,25 +1,12 @@
 package microshiftnetworking
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/microshift/storage/capabilities.go
+++ b/pkg/components/microshift/storage/capabilities.go
@@ -1,25 +1,12 @@
 package microshiftstorage
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/monitoring/capabilities.go
+++ b/pkg/components/monitoring/capabilities.go
@@ -8,14 +8,7 @@ import (
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	if strings.Contains(test.Name, "alert/") || strings.Contains(test.Name, "Alerts") || strings.Contains(test.Name, "alerting") {
 		capabilities = append(capabilities, "Alerts")

--- a/pkg/components/monitoring/grafana/capabilities.go
+++ b/pkg/components/monitoring/grafana/capabilities.go
@@ -1,25 +1,12 @@
 package monitoringgrafana
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/multiarch/arm/capabilities.go
+++ b/pkg/components/multiarch/arm/capabilities.go
@@ -1,25 +1,12 @@
 package multiarcharm
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/multiarch/capabilities.go
+++ b/pkg/components/multiarch/capabilities.go
@@ -1,25 +1,12 @@
 package multiarch
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/multiarch/ibmpandz/capabilities.go
+++ b/pkg/components/multiarch/ibmpandz/capabilities.go
@@ -1,25 +1,12 @@
 package multiarchibmpandz
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/cloudnetworkconfigcontroller/capabilities.go
+++ b/pkg/components/networking/cloudnetworkconfigcontroller/capabilities.go
@@ -1,25 +1,12 @@
 package networkingcloudnetworkconfigcontroller
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/clusternetworkoperator/capabilities.go
+++ b/pkg/components/networking/clusternetworkoperator/capabilities.go
@@ -1,25 +1,12 @@
 package networkingclusternetworkoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/dns/capabilities.go
+++ b/pkg/components/networking/dns/capabilities.go
@@ -1,25 +1,12 @@
 package networkingdns
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/ingressnodefirewall/capabilities.go
+++ b/pkg/components/networking/ingressnodefirewall/capabilities.go
@@ -1,25 +1,12 @@
 package networkingingressnodefirewall
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/kubernetesnmstate/capabilities.go
+++ b/pkg/components/networking/kubernetesnmstate/capabilities.go
@@ -1,25 +1,12 @@
 package networkingkubernetesnmstate
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/kubernetesnmstateoperator/capabilities.go
+++ b/pkg/components/networking/kubernetesnmstateoperator/capabilities.go
@@ -1,25 +1,12 @@
 package networkingkubernetesnmstateoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/kuryr/capabilities.go
+++ b/pkg/components/networking/kuryr/capabilities.go
@@ -1,25 +1,12 @@
 package networkingkuryr
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/mdns/capabilities.go
+++ b/pkg/components/networking/mdns/capabilities.go
@@ -1,25 +1,12 @@
 package networkingmdns
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/metallb/capabilities.go
+++ b/pkg/components/networking/metallb/capabilities.go
@@ -1,25 +1,12 @@
 package networkingmetallb
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/multus/capabilities.go
+++ b/pkg/components/networking/multus/capabilities.go
@@ -1,25 +1,12 @@
 package networkingmultus
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/netobs/capabilities.go
+++ b/pkg/components/networking/netobs/capabilities.go
@@ -1,25 +1,12 @@
 package networkingnetobs
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/networktools/capabilities.go
+++ b/pkg/components/networking/networktools/capabilities.go
@@ -1,25 +1,12 @@
 package networkingnetworktools
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/nmstateconsoleplugin/capabilities.go
+++ b/pkg/components/networking/nmstateconsoleplugin/capabilities.go
@@ -1,25 +1,12 @@
 package networkingnmstateconsoleplugin
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/onpremdns/capabilities.go
+++ b/pkg/components/networking/onpremdns/capabilities.go
@@ -1,25 +1,12 @@
 package networkingonpremdns
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/onpremhostnetworking/capabilities.go
+++ b/pkg/components/networking/onpremhostnetworking/capabilities.go
@@ -1,25 +1,12 @@
 package networkingonpremhostnetworking
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/onpremloadbalancer/capabilities.go
+++ b/pkg/components/networking/onpremloadbalancer/capabilities.go
@@ -1,25 +1,12 @@
 package networkingonpremloadbalancer
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/openshiftsdn/capabilities.go
+++ b/pkg/components/networking/openshiftsdn/capabilities.go
@@ -1,25 +1,12 @@
 package networkingopenshiftsdn
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/ovnkubernetes/capabilities.go
+++ b/pkg/components/networking/ovnkubernetes/capabilities.go
@@ -1,25 +1,12 @@
 package networkingovnkubernetes
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/ptp/capabilities.go
+++ b/pkg/components/networking/ptp/capabilities.go
@@ -1,25 +1,12 @@
 package networkingptp
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/router/capabilities.go
+++ b/pkg/components/networking/router/capabilities.go
@@ -1,25 +1,12 @@
 package networkingrouter
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/runtimecfg/capabilities.go
+++ b/pkg/components/networking/runtimecfg/capabilities.go
@@ -1,25 +1,12 @@
 package networkingruntimecfg
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/networking/sriov/capabilities.go
+++ b/pkg/components/networking/sriov/capabilities.go
@@ -1,25 +1,12 @@
 package networkingsriov
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/node/cpumanager/capabilities.go
+++ b/pkg/components/node/cpumanager/capabilities.go
@@ -1,25 +1,12 @@
 package nodecpumanager
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/node/crio/capabilities.go
+++ b/pkg/components/node/crio/capabilities.go
@@ -1,25 +1,12 @@
 package nodecrio
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/node/devicemanager/capabilities.go
+++ b/pkg/components/node/devicemanager/capabilities.go
@@ -1,25 +1,12 @@
 package nodedevicemanager
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/node/kubelet/capabilities.go
+++ b/pkg/components/node/kubelet/capabilities.go
@@ -1,25 +1,12 @@
 package nodekubelet
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/node/memorymanager/capabilities.go
+++ b/pkg/components/node/memorymanager/capabilities.go
@@ -1,25 +1,12 @@
 package nodememorymanager
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/node/nodeproblemdetector/capabilities.go
+++ b/pkg/components/node/nodeproblemdetector/capabilities.go
@@ -1,25 +1,12 @@
 package nodenodeproblemdetector
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/node/numaawarescheduling/capabilities.go
+++ b/pkg/components/node/numaawarescheduling/capabilities.go
@@ -1,25 +1,12 @@
 package nodenumaawarescheduling
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/node/podresourceapi/capabilities.go
+++ b/pkg/components/node/podresourceapi/capabilities.go
@@ -1,25 +1,12 @@
 package nodepodresourceapi
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/node/topologymanager/capabilities.go
+++ b/pkg/components/node/topologymanager/capabilities.go
@@ -1,25 +1,12 @@
 package nodetopologymanager
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/nodefeaturediscoveryoperator/capabilities.go
+++ b/pkg/components/nodefeaturediscoveryoperator/capabilities.go
@@ -1,25 +1,12 @@
 package nodefeaturediscoveryoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/nodemaintenanceoperator/capabilities.go
+++ b/pkg/components/nodemaintenanceoperator/capabilities.go
@@ -1,25 +1,12 @@
 package nodemaintenanceoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/nodeobservabilityoperator/capabilities.go
+++ b/pkg/components/nodeobservabilityoperator/capabilities.go
@@ -1,25 +1,12 @@
 package nodeobservabilityoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/nodetuningoperator/capabilities.go
+++ b/pkg/components/nodetuningoperator/capabilities.go
@@ -1,25 +1,12 @@
 package nodetuningoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/none/capabilities.go
+++ b/pkg/components/none/capabilities.go
@@ -1,25 +1,12 @@
 package none
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/nvidia/capabilities.go
+++ b/pkg/components/nvidia/capabilities.go
@@ -1,25 +1,12 @@
 package nvidia
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/oauthapiserver/capabilities.go
+++ b/pkg/components/oauthapiserver/capabilities.go
@@ -1,25 +1,12 @@
 package oauthapiserver
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/oauthproxy/capabilities.go
+++ b/pkg/components/oauthproxy/capabilities.go
@@ -1,25 +1,12 @@
 package oauthproxy
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/observabilityui/capabilities.go
+++ b/pkg/components/observabilityui/capabilities.go
@@ -1,25 +1,12 @@
 package observabilityui
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/oc/capabilities.go
+++ b/pkg/components/oc/capabilities.go
@@ -1,25 +1,12 @@
 package oc
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/oc/ocmirror/capabilities.go
+++ b/pkg/components/oc/ocmirror/capabilities.go
@@ -1,25 +1,12 @@
 package ococmirror
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/occompliance/capabilities.go
+++ b/pkg/components/occompliance/capabilities.go
@@ -1,25 +1,12 @@
 package occompliance
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/olm/capabilities.go
+++ b/pkg/components/olm/capabilities.go
@@ -1,25 +1,12 @@
 package olm
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/olm/operatorhub/capabilities.go
+++ b/pkg/components/olm/operatorhub/capabilities.go
@@ -1,25 +1,12 @@
 package olmoperatorhub
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/olm/registry/capabilities.go
+++ b/pkg/components/olm/registry/capabilities.go
@@ -1,25 +1,12 @@
 package olmregistry
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/openshiftapiserver/capabilities.go
+++ b/pkg/components/openshiftapiserver/capabilities.go
@@ -1,25 +1,12 @@
 package openshiftapiserver
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/openshiftcontrollermanager/apps/capabilities.go
+++ b/pkg/components/openshiftcontrollermanager/apps/capabilities.go
@@ -1,25 +1,12 @@
 package openshiftcontrollermanagerapps
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/openshiftcontrollermanager/build/capabilities.go
+++ b/pkg/components/openshiftcontrollermanager/build/capabilities.go
@@ -1,25 +1,12 @@
 package openshiftcontrollermanagerbuild
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/openshiftcontrollermanager/controllermanager/capabilities.go
+++ b/pkg/components/openshiftcontrollermanager/controllermanager/capabilities.go
@@ -1,25 +1,12 @@
 package openshiftcontrollermanagercontrollermanager
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/openshiftupdateservice/operand/capabilities.go
+++ b/pkg/components/openshiftupdateservice/operand/capabilities.go
@@ -1,25 +1,12 @@
 package openshiftupdateserviceoperand
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/openshiftupdateservice/operator/capabilities.go
+++ b/pkg/components/openshiftupdateservice/operator/capabilities.go
@@ -1,25 +1,12 @@
 package openshiftupdateserviceoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/operatorsdk/capabilities.go
+++ b/pkg/components/operatorsdk/capabilities.go
@@ -1,25 +1,12 @@
 package operatorsdk
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/performanceaddonoperator/capabilities.go
+++ b/pkg/components/performanceaddonoperator/capabilities.go
@@ -1,25 +1,12 @@
 package performanceaddonoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/podautoscaler/capabilities.go
+++ b/pkg/components/podautoscaler/capabilities.go
@@ -1,25 +1,12 @@
 package podautoscaler
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/poisonpilloperator/capabilities.go
+++ b/pkg/components/poisonpilloperator/capabilities.go
@@ -1,25 +1,12 @@
 package poisonpilloperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/registryconsole/capabilities.go
+++ b/pkg/components/registryconsole/capabilities.go
@@ -1,25 +1,12 @@
 package registryconsole
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/release/capabilities.go
+++ b/pkg/components/release/capabilities.go
@@ -1,25 +1,12 @@
 package release
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/rhcos/capabilities.go
+++ b/pkg/components/rhcos/capabilities.go
@@ -1,25 +1,12 @@
 package rhcos
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/rhmimonitoring/capabilities.go
+++ b/pkg/components/rhmimonitoring/capabilities.go
@@ -1,25 +1,12 @@
 package rhmimonitoring
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/routecontrollermanager/capabilities.go
+++ b/pkg/components/routecontrollermanager/capabilities.go
@@ -1,25 +1,12 @@
 package routecontrollermanager
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/runoncedurationoverride/capabilities.go
+++ b/pkg/components/runoncedurationoverride/capabilities.go
@@ -1,25 +1,12 @@
 package runoncedurationoverride
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/samplesoperator/capabilities.go
+++ b/pkg/components/samplesoperator/capabilities.go
@@ -1,25 +1,12 @@
 package samplesoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/sandboxedcontainers/capabilities.go
+++ b/pkg/components/sandboxedcontainers/capabilities.go
@@ -1,25 +1,12 @@
 package sandboxedcontainers
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/secondaryscheduleroperator/capabilities.go
+++ b/pkg/components/secondaryscheduleroperator/capabilities.go
@@ -1,25 +1,12 @@
 package secondaryscheduleroperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/security/capabilities.go
+++ b/pkg/components/security/capabilities.go
@@ -1,25 +1,12 @@
 package security
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/securityprofilesoperator/capabilities.go
+++ b/pkg/components/securityprofilesoperator/capabilities.go
@@ -1,25 +1,12 @@
 package securityprofilesoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/servicebinding/capabilities.go
+++ b/pkg/components/servicebinding/capabilities.go
@@ -1,25 +1,12 @@
 package servicebinding
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/servicebroker/capabilities.go
+++ b/pkg/components/servicebroker/capabilities.go
@@ -1,25 +1,12 @@
 package servicebroker
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/serviceca/capabilities.go
+++ b/pkg/components/serviceca/capabilities.go
@@ -1,25 +1,12 @@
 package serviceca
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/servicecatalog/capabilities.go
+++ b/pkg/components/servicecatalog/capabilities.go
@@ -1,25 +1,12 @@
 package servicecatalog
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/specialresourceoperator/capabilities.go
+++ b/pkg/components/specialresourceoperator/capabilities.go
@@ -1,25 +1,12 @@
 package specialresourceoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/storage/capabilities.go
+++ b/pkg/components/storage/capabilities.go
@@ -1,28 +1,15 @@
 package storage
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
+	capabilities := util.DefaultCapabilities(test)
 
 	// Storage tests use Testpattern
 	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Testpattern")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
 
 	return capabilities
 }

--- a/pkg/components/storage/kubernetes/capabilities.go
+++ b/pkg/components/storage/kubernetes/capabilities.go
@@ -1,25 +1,12 @@
 package storagekubernetes
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/storage/kubernetesexternalcomponents/capabilities.go
+++ b/pkg/components/storage/kubernetesexternalcomponents/capabilities.go
@@ -1,28 +1,15 @@
 package storagekubernetesexternalcomponents
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
+	capabilities := util.DefaultCapabilities(test)
 
 	// Storage tests use Testpattern
 	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Testpattern")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
 
 	return capabilities
 }

--- a/pkg/components/storage/localstorageoperator/capabilities.go
+++ b/pkg/components/storage/localstorageoperator/capabilities.go
@@ -1,25 +1,12 @@
 package storagelocalstorageoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/storage/openstackcsidrivers/capabilities.go
+++ b/pkg/components/storage/openstackcsidrivers/capabilities.go
@@ -1,25 +1,12 @@
 package storageopenstackcsidrivers
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/storage/operators/capabilities.go
+++ b/pkg/components/storage/operators/capabilities.go
@@ -1,25 +1,12 @@
 package storageoperators
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/storage/ovirtcsidriver/capabilities.go
+++ b/pkg/components/storage/ovirtcsidriver/capabilities.go
@@ -1,25 +1,12 @@
 package storageovirtcsidriver
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/storage/sharedresourcecsidriver/capabilities.go
+++ b/pkg/components/storage/sharedresourcecsidriver/capabilities.go
@@ -1,25 +1,12 @@
 package storagesharedresourcecsidriver
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/telcoedge/hweventoperator/capabilities.go
+++ b/pkg/components/telcoedge/hweventoperator/capabilities.go
@@ -1,25 +1,12 @@
 package telcoedgehweventoperator
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/telcoedge/ran/capabilities.go
+++ b/pkg/components/telcoedge/ran/capabilities.go
@@ -1,25 +1,12 @@
 package telcoedgeran
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/telcoedge/talo/capabilities.go
+++ b/pkg/components/telcoedge/talo/capabilities.go
@@ -1,25 +1,12 @@
 package telcoedgetalo
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/telcoedge/ztp/capabilities.go
+++ b/pkg/components/telcoedge/ztp/capabilities.go
@@ -1,25 +1,12 @@
 package telcoedgeztp
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/telemeter/capabilities.go
+++ b/pkg/components/telemeter/capabilities.go
@@ -1,25 +1,12 @@
 package telemeter
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/templates/capabilities.go
+++ b/pkg/components/templates/capabilities.go
@@ -1,25 +1,12 @@
 package templates
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/testframework/capabilities.go
+++ b/pkg/components/testframework/capabilities.go
@@ -1,25 +1,12 @@
 package testframework
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/testframework/openstack/capabilities.go
+++ b/pkg/components/testframework/openstack/capabilities.go
@@ -1,25 +1,12 @@
 package testframeworkopenstack
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/testinfrastructure/capabilities.go
+++ b/pkg/components/testinfrastructure/capabilities.go
@@ -1,25 +1,12 @@
 package testinfrastructure
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/topolvm/capabilities.go
+++ b/pkg/components/topolvm/capabilities.go
@@ -1,25 +1,12 @@
 package topolvm
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/unknown/capabilities.go
+++ b/pkg/components/unknown/capabilities.go
@@ -1,25 +1,12 @@
 package unknown
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/components/windowscontainers/capabilities.go
+++ b/pkg/components/windowscontainers/capabilities.go
@@ -1,25 +1,12 @@
 package windowscontainers
 
 import (
-	"strings"
-
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
 )
 
 func identifyCapabilities(test *v1.TestInfo) []string {
-	var capabilities []string
-
-	// Get the Feature name from the test name as a capability
-	capabilities = append(capabilities, util.ExtractTestField(test.Name, "Feature")...)
-
-	if strings.Contains(test.Name, "clusteroperator/") {
-		capabilities = append(capabilities, "Operator")
-	}
-
-	if strings.Contains(test.Name, "alert/") {
-		capabilities = append(capabilities, "Alerts")
-	}
+	capabilities := util.DefaultCapabilities(test)
 
 	return capabilities
 }

--- a/pkg/util/test_identification.go
+++ b/pkg/util/test_identification.go
@@ -4,17 +4,45 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 )
 
 var (
-	conditions   = regexp.MustCompile(`operator conditions (.*)`)
-	upgradeRegex = regexp.MustCompile(`Operator upgrade (.*)`)
-	installRegex = regexp.MustCompile("operator install (.*)")
-	imageBuild   = regexp.MustCompile("Build image (.*) from the repository")
+	conditions      = regexp.MustCompile(`operator conditions (.*)`)
+	upgradeRegex    = regexp.MustCompile(`Operator upgrade (.*)`)
+	installRegex    = regexp.MustCompile("operator install (.*)")
+	imageBuild      = regexp.MustCompile("Build image (.*) from the repository")
+	disruptionRegex = regexp.MustCompile("disruption/|connection.*should be available|remains available")
 )
+
+func DefaultCapabilities(test *v1.TestInfo) []string {
+	var capabilities []string
+
+	// Get the Feature name from the test name as a capability
+	capabilities = append(capabilities, ExtractTestField(test.Name, "Feature")...)
+
+	if strings.Contains(test.Name, "clusteroperator/") {
+		capabilities = append(capabilities, "Operator")
+	}
+
+	if strings.Contains(test.Name, "alert/") {
+		capabilities = append(capabilities, "Alerts")
+	}
+
+	if IsDisruptionTest(test.Name) {
+		capabilities = append(capabilities, "Disruption")
+	}
+
+	return capabilities
+}
 
 func IsSigTest(testName, sigName string) bool {
 	return strings.Contains(testName, fmt.Sprintf("[%s]", sigName))
+}
+
+func IsDisruptionTest(testName string) bool {
+	return disruptionRegex.MatchString(testName)
 }
 
 func IdentifyOperatorTest(operator, testName string) (isOperatorTest bool, capabilities []string) {


### PR DESCRIPTION
Add a disruption capability to all disruption tests.  Capabilities code is refactored so all the default ones (clusteroperator, alerts, disruption) come from `util` pkg.  Components can still add their own.

These are the tests flagged as disruption: https://gist.github.com/stbenjam/bbb592be4582126f95831d1de2e3663f
