### PR TITLE
Fix some unassigned tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ mapping: build
 	./ci-test-mapping map-verify
 
 unmapped:
-	jq '.[] | select(.Component == "Unknown") | .Name' mapping.json | sort | uniq
+	jq -r '.[] | select(.Component == "Unknown") | .Name' mapping.json | sort | uniq
 
 lint:
 	./hack/go-lint.sh run ./...

--- a/pkg/components/kubeapiserver/component.go
+++ b/pkg/components/kubeapiserver/component.go
@@ -39,6 +39,12 @@ var KubeApiserverComponent = Component{
 				SIG:      "sig-api-machinery",
 				Priority: -1,
 			},
+			{
+				SIG:          "sig-arch",
+				IncludeAll:   []string{"tls artifacts"},
+				Capabilities: []string{"TLS"},
+				Priority:     -1,
+			},
 		},
 		TestRenames: map[string]string{
 			"[Unknown][invariant] alert/KubePodNotReady should not be at or above info in ns/default":                                     "[bz-Unknown][invariant] alert/KubePodNotReady should not be at or above info in ns/default",

--- a/pkg/components/olm/component.go
+++ b/pkg/components/olm/component.go
@@ -12,7 +12,7 @@ type Component struct {
 var OLMComponent = Component{
 	Component: &config.Component{
 		Name:                 "OLM",
-		Operators:            []string{"marketplace", "operator-lifecycle-manager", "operator-lifecycle-manager-catalog", "operator-lifecycle-manager-packageserver"},
+		Operators:            []string{"olm", "marketplace", "operator-lifecycle-manager", "operator-lifecycle-manager-catalog", "operator-lifecycle-manager-packageserver"},
 		DefaultJiraComponent: "OLM",
 		Namespaces: []string{
 			"openshift-marketplace",

--- a/pkg/util/tests.go
+++ b/pkg/util/tests.go
@@ -4,20 +4,31 @@ import (
 	"crypto/md5"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 )
 
-var fieldRegexp = regexp.MustCompile(`\[([^\]]*):([^\]]*)\]`)
+var fieldRegexp = regexp.MustCompile(`(\[([^\]]*):([^\]]*)\]|(\w+)\/("([^"]*)"|\S+))`)
 
-// ExtractTestField gets the value of a field in a test name, e.g. [sig-storage][Driver: gce] would return
-// "gce" when extracting "Driver"
+// ExtractTestField gets the value of a field in a test name. Fields are formatted either was [Field: Value]
+// or Field/Value.  Field is case-insensitive.
 func ExtractTestField(testName, field string) (results []string) {
 	matches := fieldRegexp.FindAllStringSubmatch(testName, -1)
 	for _, match := range matches {
-		if len(match) == 3 && match[1] == field {
-			results = append(results, strings.TrimSpace(match[2]))
+		count := len(match)
+		for i, matchField := range match {
+			if !strings.EqualFold(matchField, field) || count < i+2 {
+				continue
+			}
+
+			value := strings.TrimSpace(match[i+1])
+			unquoted, err := strconv.Unquote(value)
+			if err == nil {
+				value = unquoted
+			}
+			results = append(results, value)
 		}
 	}
 

--- a/pkg/util/tests_test.go
+++ b/pkg/util/tests_test.go
@@ -13,10 +13,28 @@ func TestExtractField(t *testing.T) {
 		wantValues []string
 	}{
 		{
-			name:       "can extract single value",
+			name:       "can extract bracketed single value",
 			test:       "[sig-storage] In-tree Volumes [Driver: windows-gcepd] [Testpattern: Dynamic PV (ntfs)][Feature:Windows] subPath should be able to unmount after the subpath directory is deleted [LinuxOnly] [Skipped:NoOptionalCapabilities] [Suite:openshift/conformance/parallel] [Suite:k8s]",
 			field:      "Driver",
 			wantValues: []string{"windows-gcepd"},
+		},
+		{
+			name:       "can extract slash single value",
+			test:       `jira/"Test Framework" validate the thing works`,
+			field:      "jira",
+			wantValues: []string{"Test Framework"},
+		},
+		{
+			name:       "can extract fields case-insensitive",
+			test:       `jira/"Test Framework" [Jira: Networking]`,
+			field:      "JIRA",
+			wantValues: []string{"Test Framework", "Networking"},
+		},
+		{
+			name:       "can extract slash multiple value",
+			test:       `jira/"Test Framework" jira/Installer validate the thing works`,
+			field:      "jira",
+			wantValues: []string{"Test Framework", "Installer"},
 		},
 		{
 			name:       "handles field not present",


### PR DESCRIPTION
- Extract fields from tests using both formats, i.e. `[Field: value]` and `field/value`.
- Assign tls tests to Test Framework
- "olm" operator to belong to OLM component