### PR TITLE
Fix assignment of control plane machine set operator tests

### DIFF
--- a/pkg/components/cloudcompute/otherprovider/component.go
+++ b/pkg/components/cloudcompute/otherprovider/component.go
@@ -31,6 +31,7 @@ var OtherProviderComponent = Component{
 					"bz-cluster-api",
 					"bz-control-plane-machine-set",
 					"Managed cluster should have same number of Machines and Nodes",
+					"control plane machine set operator",
 				},
 			},
 			{


### PR DESCRIPTION
This test belongs in Cloud Compute:

```
[sig-cluster-lifecycle][Feature:Machines] Managed cluster should [sig-scheduling][Early] control plane machine set operator should not have any events [Suite:openshift/conformance/parallel]
```