### PR TITLE
kubeapiserver: exclude sig-node alerts

### DIFF
--- a/pkg/components/kubeapiserver/component.go
+++ b/pkg/components/kubeapiserver/component.go
@@ -48,6 +48,12 @@ var KubeApiserverComponent = Component{
 				Capabilities: []string{"TLS"},
 				Priority:     -1,
 			},
+			{
+				SIG:          "sig-node",
+				IncludeAll:   []string{"TargetDown should not be at or above info in ns/kube-system"},
+				Capabilities: []string{"Alerts"},
+				Priority:     -10,
+			},
 		},
 		TestRenames: map[string]string{
 			"[Unknown][invariant] alert/KubePodNotReady should not be at or above info in ns/default":                                                       "[bz-Unknown][invariant] alert/KubePodNotReady should not be at or above info in ns/default",


### PR DESCRIPTION
Several "TargetDown alert firing in kube-system namespace" failing tests were mistakenly attributed as kubeapiserver regressions: https://sippy.dptools.openshift.org/sippy-ng/component_readiness/env_capability?arch=amd64&arch=amd64&baseEndTime=2024-02-28%2023%3A59%3A59&baseRelease=4.15&baseStartTime=2024-02-01%2000%3A00%3A00&capability=Alerts&component=kube-apiserver&confidence=95&environment=sdn%20amd64%20aws&environment=sdn%20amd64%20aws&excludeArches=arm64%2Cheterogeneous%2Cppc64le%2Cs390x&excludeClouds=openstack%2Cibmcloud%2Clibvirt%2Covirt%2Cunknown&excludeVariants=hypershift%2Cosd%2Cmicroshift%2Ctechpreview%2Csingle-node%2Cassisted%2Ccompact&groupBy=cloud%2Carch%2Cnetwork&ignoreDisruption=true&ignoreMissing=false&minFail=3&network=sdn&network=sdn&pity=5&platform=aws&platform=aws&sampleEndTime=2024-05-16%2023%3A59%3A59&sampleRelease=4.16&sampleStartTime=2024-05-10%2000%3A00%3A00