### PR TITLE
add OLM v1 namespaces

### DIFF
--- a/pkg/components/olm/component.go
+++ b/pkg/components/olm/component.go
@@ -18,6 +18,9 @@ var OLMComponent = Component{
 			"openshift-marketplace",
 			"openshift-operator-lifecycle-manager",
 			"openshift-operators",
+			"openshift-operator-controller",
+			"openshift-cluster-olm-operator",
+			"openshift-rukpak",
 		},
 		Matchers: []config.ComponentMatcher{
 			{


### PR DESCRIPTION
As title, we have many test cases for the OLM v1 although it's TP. The related namespaces are installed after enabling the `featuregate`. 
```console
jiazha-mac:~ jiazha$ oc get featuregate cluster -o yaml
apiVersion: config.openshift.io/v1
kind: FeatureGate
metadata:
  annotations:
    include.release.openshift.io/self-managed-high-availability: "true"
  creationTimestamp: "2024-05-21T01:08:23Z"
  generation: 2
  name: cluster
  resourceVersion: "110841"
  uid: 50a6cf44-64a0-4237-b9b3-f7daa29d3161
spec:
  featureSet: TechPreviewNoUpgrade
status:
...
jiazha-mac:~ jiazha$ oc get ns|grep rukpak 
openshift-rukpak                                   Active   140m
jiazha-mac:~ jiazha$ oc get ns |grep olm 
openshift-cluster-olm-operator                     Active   140m
jiazha-mac:~ jiazha$ oc get ns|grep operator-controller 
openshift-operator-controller                      Active   149m
```
