### PR TITLE
OTA-1243: Sort `Other` CVO tests to capabilities

### DIFF
--- a/pkg/components/clusterversionoperator/OWNERS
+++ b/pkg/components/clusterversionoperator/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - PratikMahajan
+  - petr-muller
+  - wking

--- a/pkg/components/clusterversionoperator/capabilities.go
+++ b/pkg/components/clusterversionoperator/capabilities.go
@@ -1,12 +1,46 @@
 package clusterversionoperator
 
 import (
+	"regexp"
+
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/util"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func identifyCapabilities(test *v1.TestInfo) []string {
-	capabilities := util.DefaultCapabilities(test)
+const (
+	// ClusterUpgrade is a CVO capability to upgrade the cluster
+	ClusterUpgrade = "ClusterUpgrade"
+	// ClusterOperators is a CVO capability to manage and monitor Cluster Operators
+	ClusterOperators = "ClusterOperators"
+	// Operator is a CVO capability to operate the cluster both during and outside of upgrades
+	Operator = "Operator"
+	// AdminAck is a CVO capability to process administrator acknowledgements
+	AdminAck = "AdminAck"
+)
 
-	return capabilities
+var cvoCapabilitiesIdentifiers = map[*regexp.Regexp]string{
+	regexp.MustCompile(`.*upgrade.*`): ClusterUpgrade,
+
+	// e.g. [sig-cluster-lifecycle] pathological event should not see excessive Back-off restarting failed containers for ns/openshift-cluster-version
+	regexp.MustCompile(".*ns/openshift-cluster-version.*"): Operator,
+	// all invariant tests
+	// e.g. [Jira:"Cluster Version Operator"] monitor test legacy-cvo-invariants collection
+	regexp.MustCompile(".*monitor test.*"): Operator,
+
+	// e.g. Cluster upgrade.[sig-cluster-lifecycle] ClusterOperators are available and not degraded after upgrade
+	regexp.MustCompile(".*ClusterOperators.*"): ClusterOperators,
+
+	regexp.MustCompile(`.*(admin ack|AdminAck).*`): AdminAck,
+}
+
+func identifyCapabilities(test *v1.TestInfo) []string {
+	capabilities := sets.New[string](util.DefaultCapabilities(test)...)
+	for matcher, capability := range cvoCapabilitiesIdentifiers {
+		if matcher.MatchString(test.Name) {
+			capabilities.Insert(capability)
+		}
+	}
+
+	return capabilities.UnsortedList()
 }

--- a/pkg/components/machineconfigoperator/component.go
+++ b/pkg/components/machineconfigoperator/component.go
@@ -39,6 +39,9 @@ var MachineConfigOperatorComponent = Component{
 				IncludeAll:   []string{"Pods cannot access the /config"},
 				Capabilities: []string{"Config"},
 			},
+			{
+				SIG: "sig-mco",
+			},
 		},
 		TestRenames: map[string]string{
 			"[Machine Config Operator][invariant] alert/KubePodNotReady should not be at or above info in ns/openshift-machine-config-operator":    "[bz-Machine Config Operator][invariant] alert/KubePodNotReady should not be at or above info in ns/openshift-machine-config-operator",


### PR DESCRIPTION
[OTA-1243: Set OWNERS for CVO](https://github.com/openshift-eng/ci-test-mapping/pull/124/commits/222378ad4644e14801f7ef1aaa3261491d17d6a8)

Follow CVO owners changed in https://github.com/openshift/cluster-version-operator/pull/1058

--- 

[OTA-1243: Sort Other CVO tests to capabilities](https://github.com/openshift-eng/ci-test-mapping/pull/124/commits/1d7bca51e71a064fd3dd6eef17a1cc0ca84f0e33)

In addition to the existing `ClusterUpgrade` capability, introduce new `ClusterOperators`, `Operator` and `AdminAck` capabilities to cover what CVO does.

---

[OTA-1243: Move [sig-mco] Machine config pools complete upgrade to MCO](https://github.com/openshift-eng/ci-test-mapping/pull/124/commits/a5f00889c0208cdca7c0f3dbec39cbfe57fcf98d)