### PR TITLE
Correct apiserver-auth and cert-manager QE test mappings

### DIFF
--- a/pkg/components/apiserverauth/component.go
+++ b/pkg/components/apiserverauth/component.go
@@ -22,19 +22,10 @@ var ApiserverAuthComponent = Component{
 			{
 				IncludeAll: []string{"bz-apiserver-auth"},
 			},
-			{Suite: "Authentication"},
-			{Suite: "Group sync related scenarios"},
-			{Suite: "SCC policy related scenarios"},
-			{Suite: "Seccomp part of SCC policy should be kept and working after upgrade"},
-			{Suite: "User management related"},
-			{Suite: "apiserver and auth related upgrade check"},
-			{Suite: "auth prometheus metrics feature"},
-			{Suite: "change the policy of user/service account"},
-			{Suite: "groups and users related features"},
-			{Suite: "idp feature"},
-			{Suite: "permission related test"},
-			{Suite: "token feature"},
-			{Suite: "certificates related scenarios"},
+			{
+				IncludeAny: []string{":Authentication ", ":Authentication:"}, // Auth QE cases all include either ":Authentication " (for cucushift cases) or ":Authentication:" (for go-lang cases) in junit xml
+				Priority:   20,
+			},
 		},
 		TestRenames: map[string]string{
 			"[apiserver-auth][invariant] alert/KubePodNotReady should not be at or above info in ns/openshift-authentication":             "[bz-apiserver-auth][invariant] alert/KubePodNotReady should not be at or above info in ns/openshift-authentication",

--- a/pkg/components/certmanager/component.go
+++ b/pkg/components/certmanager/component.go
@@ -18,6 +18,9 @@ var CertManagerComponent = Component{
 			{
 				IncludeAll: []string{"bz-cert-manager"},
 			},
+			{
+				IncludeAll: []string{"CFE cert-manager"}, // cert-manager QE cases all have "CFE cert-manager" in junit xml
+			},
 		},
 	},
 }


### PR DESCRIPTION
@stbenjam the apiserverauth/component.go in #135 is not quite correct, e.g. [{Suite: "certificates related scenarios"}](https://github.com/openshift/cucushift/blob/248882e0822949fc4024a9b6e5ef9b587eeef71e/admin/certificates.feature#L1) and [{Suite: "permission related test"}](https://github.com/openshift/verification-tests/blob/217aa1554f5178781286b2b75dee711aa14d1cc4/features/logging/permission.feature#L1-L2) et al are not Auth QE's cases, but #135 added them as `apiserver-auth` component. As Auth/cert-manager QE team lead, I'm correcting Auth/cert-manager QE test mappings, based on https://docs.google.com/presentation/d/1xhgNC6ECeuyDW8CIEiu7m0GetQAcOEs8UFEj7Fj3WfY/edit#slide=id.g2e2e3877f6e_0_12 info. Could you help check/merge? Thanks!