### PR TITLE
Update testname mapping for renamed tests due to new apps.openshift.io dependency

### DIFF
--- a/pkg/components/build/component.go
+++ b/pkg/components/build/component.go
@@ -28,6 +28,10 @@ var BuildComponent = Component{
 			{Suite: "buildlogic.feature"},
 			{Suite: "admin build related features"},
 		},
+		TestRenames: map[string]string{
+			"[sig-devex][Feature:Templates] templateinstance readiness test should report failed soon after an annotated objects has failed [apigroup:template.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]": "[sig-devex][Feature:Templates] templateinstance readiness test should report failed soon after an annotated objects has failed [apigroup:template.openshift.io][apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+			"[sig-devex][Feature:Templates] templateinstance readiness test should report ready soon after all annotated objects are ready [apigroup:template.openshift.io][apigroup:build.openshift.io][apigroup:apps.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]":  "[sig-devex][Feature:Templates] templateinstance readiness test should report ready soon after all annotated objects are ready [apigroup:template.openshift.io][apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+		},
 	},
 }
 

--- a/pkg/components/oc/component.go
+++ b/pkg/components/oc/component.go
@@ -69,6 +69,11 @@ var OcComponent = Component{
 			{Suite: "oc plugin related tests"},
 			{Suite: "oc/kubernetes version related features"},
 		},
+		TestRenames: map[string]string{
+			"[sig-cli] oc adm build-chain [apigroup:build.openshift.io][apigroup:image.openshift.io][apigroup:project.openshift.io][apigroup:apps.openshift.io] [Suite:openshift/conformance/parallel]": "[sig-cli] oc adm build-chain [apigroup:build.openshift.io][apigroup:image.openshift.io][apigroup:project.openshift.io] [Suite:openshift/conformance/parallel]",
+			"[sig-cli] oc builds complex build start-build [apigroup:build.openshift.io][apigroup:apps.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]":                     "[sig-cli] oc builds complex build start-build [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+			"[sig-cli] oc builds complex build webhooks CRUD [apigroup:build.openshift.io][apigroup:apps.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]":                   "[sig-cli] oc builds complex build webhooks CRUD [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+		},
 	},
 }
 


### PR DESCRIPTION
Update after https://github.com/openshift/origin/pull/28951.