### PR TITLE
TRT-1855: update perfscale suites

### DIFF
--- a/config/openshift-eng.yaml
+++ b/config/openshift-eng.yaml
@@ -7,7 +7,9 @@ includeSuites:
   - cluster install
   - Operator results
   - Symptom Detection
-  - payload-cluster-density-v2 nightly compare
+  - perfscale-cdv2
+  - perfscale-nd
+  - perfscale-crd
 excludeSuites: []
 excludeTests:
   - "Build image%"


### PR DESCRIPTION
Suggestions for shortened suite names from perfscale team:

```
`perfscale-cdv2` for cluster-density-v2

`perfscale-nd` for node-density

`perfscale-crd` for crd-scale
```
