### PR TITLE
OCPQE-26800 update ota qe test mapping

### DIFF
--- a/pkg/components/clusterversionoperator/component.go
+++ b/pkg/components/clusterversionoperator/component.go
@@ -52,18 +52,10 @@ var ClusterVersionOperatorComponent = Component{
 					"[sig-cluster-lifecycle] TestAdminAck should succeed [Suite:openshift/conformance/parallel]",
 				},
 			},
-			{Suite: "Operators related features"},
-			{Suite: "Cluster_Operator"},
-			{Suite: "Display All Namespace Operands for Global Operators"},
-			{Suite: "OTA"},
-			{Suite: "Operators related features"},
-			{Suite: "Scenarios which will be used both for function checking and upgrade checking"},
-			{Suite: "basic verification for upgrade testing"},
-			{Suite: "cluster upgrade"},
-			{Suite: "fips enabled verification for upgrade"},
-			{Suite: "operand tests"},
-			{Suite: "Operators Installed nonlatest operator test"},
-			{Suite: "Operators related features on sts cluster mode"},
+			{
+				// all cvo QE cases from ginkgo include "OTA cvo" and prow ci include "cluster upgrade" in junit xml
+				IncludeAny: []string{"OTA cvo", "cluster upgrade"},
+			},
 		},
 	},
 }

--- a/pkg/components/oc/update/component.go
+++ b/pkg/components/oc/update/component.go
@@ -14,7 +14,14 @@ var UpdateComponent = Component{
 		Name:                 "oc / update",
 		Operators:            []string{},
 		DefaultJiraComponent: "oc / update",
-		Matchers:             []config.ComponentMatcher{},
+		Matchers: []config.ComponentMatcher{
+			{
+				// all OTA team oc QE cases from ginkgo include "OTA oc" in junit xml
+				IncludeAny: []string{
+					"OTA oc",
+				},
+			},
+		},
 	},
 }
 

--- a/pkg/components/openshiftupdateservice/operator/component.go
+++ b/pkg/components/openshiftupdateservice/operator/component.go
@@ -14,7 +14,14 @@ var OperatorComponent = Component{
 		Name:                 "OpenShift Update Service / operator",
 		Operators:            []string{},
 		DefaultJiraComponent: "OpenShift Update Service / operator",
-		Matchers:             []config.ComponentMatcher{},
+		Matchers: []config.ComponentMatcher{
+			{
+				// all osus QE cases from ginkgo include "OTA osus" in junit xml
+				IncludeAny: []string{
+					"OTA osus",
+				},
+			},
+		},
 	},
 }
 


### PR DESCRIPTION
1. Correct the suite which added in https://github.com/openshift-eng/ci-test-mapping/pull/135. Those suites are not belong to OTA qe team
2. Add qe test mapping for oc/update and openShift update service /operator component(currently all osus cases are including OTA osus in the name, but not distinguish operator and operand subcomponent)

Local test result:
```
$ make mapping
go build .
# OCP Engineering
./ci-test-mapping map --mode=local
INFO[0000] mapping tests to ownership                   
INFO[0000] loading jira ocpbugs component information... 
INFO[0003] jira ocpbugs components loaded in 3.68929117s 
INFO[0051] mapping tests to ownership complete in 51.097622585s  matched=22236 unmatched=1716
INFO[0051] writing results to file                      
INFO[0051] write complete in 115.724078ms               
# QE
./ci-test-mapping map --bigquery-dataset ci_analysis_us --bigquery-project openshift-gce-devel --bigquery-dataset ci_analysis_qe --table-junit junit --table-mapping component_mapping --mode=local --config ""
INFO[0000] mapping tests to ownership                   
INFO[0000] loading jira ocpbugs component information... 
INFO[0002] jira ocpbugs components loaded in 2.621501932s 
INFO[0031] mapping tests to ownership complete in 31.085135548s  matched=13089 unmatched=3654
INFO[0031] writing results to file                      
INFO[0031] write complete in 71.713197ms                
# Verify mappings don't move anything into Unknown
./ci-test-mapping map-verify
INFO[0000] verifying mappings are correct...            
INFO[0011] verification complete in 11.988002423s       
```