### PR TITLE
OAPE-118: rename CFE to OAP

### DIFF
--- a/pkg/components/certmanager/component.go
+++ b/pkg/components/certmanager/component.go
@@ -19,7 +19,11 @@ var CertManagerComponent = Component{
 				IncludeAll: []string{"bz-cert-manager"},
 			},
 			{
-				IncludeAll: []string{"CFE cert-manager"}, // cert-manager QE cases all have "CFE cert-manager" in junit xml
+				IncludeAny: []string{
+					"CFE cert-manager",
+					"OAP cert-manager",
+					":CFE:",
+				},
 			},
 		},
 	},


### PR DESCRIPTION
https://issues.redhat.com/browse/OAPE-118
remane CFE (Customer Focus Engineering) to OAP (OpenShift Application Platform)

follow-up to update
https://github.com/openshift/openshift-tests-private/pull/23115
https://github.com/openshift/release/pull/61494
