### PR TITLE
Fix mapping verify command

### DIFF
--- a/cmd/ci-test-mapping/mapping_verify.go
+++ b/cmd/ci-test-mapping/mapping_verify.go
@@ -19,7 +19,7 @@ import (
 var verifyMapFlags = NewVerifyMapFlags()
 var mappingFiles = []string{
 	"data/openshift-gce-devel/ci_analysis_us/component_mapping.json",
-	"data/openshift-gce-devel/ci_analaysis_us/qe_component_mapping.json",
+	"data/openshift-gce-devel/ci_analysis_qe/component_mapping.json",
 }
 
 type VerifyMapFlags struct {
@@ -51,6 +51,11 @@ var verifyMapCmd = &cobra.Command{
 				fmt.Println("Failed to fetch data:", err)
 				return
 			}
+			if response.StatusCode != 200 {
+				fmt.Println("Failed to fetch data:", response.StatusCode)
+				return
+			}
+
 			currentMap, err := fetchMap(response.Body)
 			if err != nil {
 				logrus.WithError(err).Fatalf("couldn't fetch current mapping")


### PR DESCRIPTION
Tests moving to Unknown aren't detected for QE because the file was named incorrectly.

And http.Get doesn't return an error for 404 -- it's only in the status code.

<!--

Thanks for contributing to ci-test-mapping.

Please make sure to run `make mapping` and commit the results when
making changes to test ownership. To have your PR's tested
automatically, join the openshift-eng GitHub organization. See the
instructions on #forum-pge-cloud-ops on Slack.

Please see README.md for additional information how about
this repo works.

-->
