### PR TITLE
move operatorhub test case to the Console component

### DIFF
--- a/pkg/components/managementconsole/component.go
+++ b/pkg/components/managementconsole/component.go
@@ -31,6 +31,8 @@ var ManagementConsoleComponent = Component{
 					"upgrade should succeed: console",
 				},
 			},
+			{Suite: "Operator Hub tests"},
+			{Suite: "operatorhub feature related"},
 		},
 		TestRenames: map[string]string{
 			"[Management Console][invariant] alert/KubePodNotReady should not be at or above info in ns/openshift-console":             "[bz-Management Console][invariant] alert/KubePodNotReady should not be at or above info in ns/openshift-console",

--- a/pkg/components/olm/operatorhub/component.go
+++ b/pkg/components/olm/operatorhub/component.go
@@ -14,9 +14,11 @@ var OperatorHubComponent = Component{
 		Name:                 "OLM / OperatorHub",
 		Operators:            []string{},
 		DefaultJiraComponent: "OLM / OperatorHub",
-		Matchers: []config.ComponentMatcher{
-			{Suite: "Operator Hub tests"},
-			{Suite: "operatorhub feature related"},
+		Matchers:             []config.ComponentMatcher{
+			// No QE OLM test cases belong to this component.
+			// These test case should belong to the Console team. Such as `Operator Hub tests.Operator Hub tests (OCP-62266,xiyuzhao,UserInterface) Filter operators based on nodes OS type`
+			// {Suite: "Operator Hub tests"},
+			// {Suite: "operatorhub feature related"},
 		},
 	},
 }


### PR DESCRIPTION
These `Operator Hub tests` test cases belong to the Console team, not OLM. So update the case mapping. See:
[OLM / OperatorHub > Other](https://qe-component-readiness.dptools.openshift.org/sippy-ng/component_readiness/env_capability?Architecture=amd64&Architecture=amd64&Network=ovn&Network=ovn&Platform=gcp&Platform=gcp&baseEndTime=2025-02-25%2023%3A59%3A59&baseRelease=4.18&baseStartTime=2025-01-26%2000%3A00%3A00&capability=Other&columnGroupBy=Architecture%2CNetwork%2CPlatform&component=OLM%20%2F%20OperatorHub&confidence=95&dbGroupBy=Platform%2CArchitecture%2CNetwork%2CTopology%2CFeatureSet%2CUpgrade%2CSuite%2CInstaller&environment=amd64%20ovn%20gcp&environment=amd64%20ovn%20gcp&flakeAsFailure=false&ignoreDisruption=true&ignoreMissing=false&includeMultiReleaseAnalysis=false&includeVariant=Architecture%3Aamd64&includeVariant=FeatureSet%3Adefault&includeVariant=Installer%3Aipi&includeVariant=Installer%3Aupi&includeVariant=Network%3Aovn&includeVariant=Owner%3Aqe&includeVariant=Owner%3Aservice-delivery&includeVariant=Platform%3Aaws&includeVariant=Platform%3Aazure&includeVariant=Platform%3Agcp&includeVariant=Platform%3Arosa&includeVariant=Platform%3Avsphere&includeVariant=Topology%3Aha&minFail=3&passRateAllTests=0&passRateNewTests=0&pity=5&sampleEndTime=2025-05-21%2023%3A59%3A59&sampleRelease=4.19&sampleStartTime=2025-05-14%2000%3A00%3A00)
<img width="454" alt="image" src="https://github.com/user-attachments/assets/812a42af-39fe-4c84-9629-0f2f121f2f4c" />
