### PR TITLE
NO-JIRA: add lint timeout and version info

### DIFF
--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -7,7 +7,9 @@ set -ex
 
 if [ "$CI" = "true" ];
 then
-  golangci-lint "${@}"
+  go version
+  golangci-lint version -v
+  golangci-lint --timeout 10m "${@}"
 else
   DOCKER=${DOCKER:-podman}
 


### PR DESCRIPTION
Follow up to https://github.com/openshift-eng/ci-test-mapping/pull/354. With the new version it is timing out.
