### PR TITLE
Add the CNV-lp-interop component

### DIFF
--- a/pkg/components/cnvlpinterop/capabilities.go
+++ b/pkg/components/cnvlpinterop/capabilities.go
@@ -1,0 +1,12 @@
+package cnvlpinterop
+
+import (
+	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
+	"github.com/openshift-eng/ci-test-mapping/pkg/util"
+)
+
+func identifyCapabilities(test *v1.TestInfo) []string {
+	capabilities := util.DefaultCapabilities(test)
+
+	return capabilities
+}

--- a/pkg/components/cnvlpinterop/component.go
+++ b/pkg/components/cnvlpinterop/component.go
@@ -14,9 +14,7 @@ var CNVLpInteropComponent = Component{
 		Name:                 "CNV-lp-interop",
 		Operators:            []string{},
 		DefaultJiraComponent: "CNV-lp-interop",
-		Matchers:             []config.ComponentMatcher{
-			{Suite: "CNV-lp-interop"},
-		},
+		Matchers:             []config.ComponentMatcher{{Suite: "CNV-lp-interop"}},
 	},
 }
 

--- a/pkg/components/cnvlpinterop/component.go
+++ b/pkg/components/cnvlpinterop/component.go
@@ -1,0 +1,54 @@
+package cnvlpinterop
+
+import (
+	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
+	"github.com/openshift-eng/ci-test-mapping/pkg/config"
+)
+
+type Component struct {
+	*config.Component
+}
+
+var CNVLpInteropComponent = Component{
+	Component: &config.Component{
+		Name:                 "CNV-lp-interop",
+		Operators:            []string{},
+		DefaultJiraComponent: "CNV-lp-interop",
+		Matchers:             []config.ComponentMatcher{},
+	},
+}
+
+func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
+	if matcher := c.FindMatch(test); matcher != nil {
+		jira := matcher.JiraComponent
+		if jira == "" {
+			jira = c.DefaultJiraComponent
+		}
+		return &v1.TestOwnership{
+			Name:          test.Name,
+			Component:     c.Name,
+			JIRAComponent: jira,
+			Priority:      matcher.Priority,
+			Capabilities:  append(matcher.Capabilities, identifyCapabilities(test)...),
+		}, nil
+	}
+
+	return nil, nil
+}
+
+func (c *Component) StableID(test *v1.TestInfo) string {
+	// Look up the stable name for our test in our renamed tests map.
+	if stableName, ok := c.TestRenames[test.Name]; ok {
+		return stableName
+	}
+	return test.Name
+}
+
+func (c *Component) JiraComponents() (components []string) {
+	components = []string{c.DefaultJiraComponent}
+	for _, m := range c.Matchers {
+		components = append(components, m.JiraComponent)
+	}
+
+	return components
+}

--- a/pkg/components/cnvlpinterop/component.go
+++ b/pkg/components/cnvlpinterop/component.go
@@ -14,7 +14,9 @@ var CNVLpInteropComponent = Component{
 		Name:                 "CNV-lp-interop",
 		Operators:            []string{},
 		DefaultJiraComponent: "CNV-lp-interop",
-		Matchers:             []config.ComponentMatcher{},
+		Matchers:             []config.ComponentMatcher{
+			{Suite: "CNV-lp-interop"},
+		},
 	},
 }
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,6 +1,14 @@
 package registry
 
 import (
+	"github.com/openshift-eng/ci-test-mapping/pkg/components/zerotrustworkloadidentitymanager"
+	"github.com/openshift-eng/ci-test-mapping/pkg/components/secretsstorecsidriver"
+	"github.com/openshift-eng/ci-test-mapping/pkg/components/ocloudmanageroperator"
+	"github.com/openshift-eng/ci-test-mapping/pkg/components/leaderworkerset"
+	"github.com/openshift-eng/ci-test-mapping/pkg/components/jobset"
+	"github.com/openshift-eng/ci-test-mapping/pkg/components/externalsecretsoperator"
+	"github.com/openshift-eng/ci-test-mapping/pkg/components/ebpfmanager"
+	"github.com/openshift-eng/ci-test-mapping/pkg/components/cnvlpinterop"
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/apiserverauth"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/awsloadbalanceroperator"
@@ -435,6 +443,14 @@ func NewComponentRegistry() *Registry {
 	r.Register("secondary-scheduler-operator", &secondaryscheduleroperator.SecondarySchedulerOperatorComponent)
 	r.Register("service-ca", &serviceca.ServiceCaComponent)
 	r.Register("spire-operator", &spireoperator.SpireOperatorComponent)
+	r.Register("CNV-lp-interop", &cnvlpinterop.CNVLpInteropComponent)
+	r.Register("eBPF Manager", &ebpfmanager.EBPFManagerComponent)
+	r.Register("External Secrets Operator", &externalsecretsoperator.ExternalSecretsOperatorComponent)
+	r.Register("JobSet", &jobset.JobSetComponent)
+	r.Register("LeaderWorkerSet", &leaderworkerset.LeaderWorkerSetComponent)
+	r.Register("O-Cloud Manager Operator", &ocloudmanageroperator.OCloudManagerOperatorComponent)
+	r.Register("Secrets Store CSI driver", &secretsstorecsidriver.SecretsStoreCSIDriverComponent)
+	r.Register("zero-trust-workload-identity-manager", &zerotrustworkloadidentitymanager.ZeroTrustWorkloadIdentityManagerComponent)
 	// New components go here
 
 	return &r

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,13 +1,6 @@
 package registry
 
 import (
-	"github.com/openshift-eng/ci-test-mapping/pkg/components/zerotrustworkloadidentitymanager"
-	"github.com/openshift-eng/ci-test-mapping/pkg/components/secretsstorecsidriver"
-	"github.com/openshift-eng/ci-test-mapping/pkg/components/ocloudmanageroperator"
-	"github.com/openshift-eng/ci-test-mapping/pkg/components/leaderworkerset"
-	"github.com/openshift-eng/ci-test-mapping/pkg/components/jobset"
-	"github.com/openshift-eng/ci-test-mapping/pkg/components/externalsecretsoperator"
-	"github.com/openshift-eng/ci-test-mapping/pkg/components/ebpfmanager"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/cnvlpinterop"
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/apiserverauth"
@@ -444,13 +437,6 @@ func NewComponentRegistry() *Registry {
 	r.Register("service-ca", &serviceca.ServiceCaComponent)
 	r.Register("spire-operator", &spireoperator.SpireOperatorComponent)
 	r.Register("CNV-lp-interop", &cnvlpinterop.CNVLpInteropComponent)
-	r.Register("eBPF Manager", &ebpfmanager.EBPFManagerComponent)
-	r.Register("External Secrets Operator", &externalsecretsoperator.ExternalSecretsOperatorComponent)
-	r.Register("JobSet", &jobset.JobSetComponent)
-	r.Register("LeaderWorkerSet", &leaderworkerset.LeaderWorkerSetComponent)
-	r.Register("O-Cloud Manager Operator", &ocloudmanageroperator.OCloudManagerOperatorComponent)
-	r.Register("Secrets Store CSI driver", &secretsstorecsidriver.SecretsStoreCSIDriverComponent)
-	r.Register("zero-trust-workload-identity-manager", &zerotrustworkloadidentitymanager.ZeroTrustWorkloadIdentityManagerComponent)
 	// New components go here
 
 	return &r

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,7 +1,6 @@
 package registry
 
 import (
-	"github.com/openshift-eng/ci-test-mapping/pkg/components/cnvlpinterop"
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/apiserverauth"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/awsloadbalanceroperator"
@@ -41,6 +40,7 @@ import (
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/clusterresourceoverrideadmissionoperator"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/clusterversionoperator"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/cnfcerttnf"
+	"github.com/openshift-eng/ci-test-mapping/pkg/components/cnvlpinterop"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/complianceoperator"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/confidentialcomputeattestation"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/configoperator"


### PR DESCRIPTION
- Added the `pkg/components/cnvlpinterop/` repo
- Modified the `ComponentMatcher` manually
- Verified changes with `make mapping`

<!--

Thanks for contributing to ci-test-mapping.

Please make sure to run `make mapping` and commit the results when
making changes to test ownership. To have your PR's tested
automatically, join the openshift-eng GitHub organization. See the
instructions on #forum-pge-cloud-ops on Slack.

Please see README.md for additional information how about
this repo works.

-->
