### PR TITLE
OCPNODE-3599: sig-imagepolicy matcher node/crio component

### DIFF
--- a/pkg/components/node/crio/component.go
+++ b/pkg/components/node/crio/component.go
@@ -21,6 +21,9 @@ var CRIOComponent = Component{
 				},
 			},
 			{Suite: "Container_Engine_Tools"},
+			{
+				SIG: "sig-imagepolicy",
+			},
 		},
 	},
 }


### PR DESCRIPTION
<!--

Thanks for contributing to ci-test-mapping.

Please make sure to run `make mapping` and commit the results when
making changes to test ownership. To have your PR's tested
automatically, join the openshift-eng GitHub organization. See the
instructions on #forum-pge-cloud-ops on Slack.

Please see README.md for additional information how about
this repo works.

-->
https://github.com/openshift/origin/blob/main/test/extended/imagepolicy/imagepolicy.go
sig-imagepolicy tests maps to node/crio component