### PR TITLE
change ownership of fips test to Security component

### DIFF
--- a/pkg/components/node/crio/component.go
+++ b/pkg/components/node/crio/component.go
@@ -15,11 +15,6 @@ var CRIOComponent = Component{
 		Operators:            []string{},
 		DefaultJiraComponent: "Node / CRI-O",
 		Matchers: []config.ComponentMatcher{
-			{
-				IncludeAny: []string{
-					"[sig-arch] [Conformance] FIPS TestFIPS",
-				},
-			},
 			{Suite: "Container_Engine_Tools"},
 			{
 				SIG: "sig-imagepolicy",

--- a/pkg/components/security/component.go
+++ b/pkg/components/security/component.go
@@ -18,6 +18,7 @@ var SecurityComponent = Component{
 			{
 				IncludeAny: []string{
 					":SecurityandCompliance ",
+					"[sig-arch] [Conformance] FIPS TestFIPS",
 				},
 				Priority: 1,
 			},


### PR DESCRIPTION
[sig-arch] [Conformance] FIPS TestFIPS [Suite:openshift/conformance/parallel/minimal] was assigned to "Node / CRIO" component .  The Security and Compliance team moved out of Node.  The test should be assigned to the Security component.

<!--

Thanks for contributing to ci-test-mapping.

Please make sure to run `make mapping` and commit the results when
making changes to test ownership. To have your PR's tested
automatically, join the openshift-eng GitHub organization. See the
instructions on #forum-pge-cloud-ops on Slack.

Please see README.md for additional information how about
this repo works.

-->
