### PR TITLE
Register new LP patterns

### DIFF
--- a/config/openshift-eng.yaml
+++ b/config/openshift-eng.yaml
@@ -31,7 +31,9 @@ includeSuites:
   - Machine Suite
 excludeSuites: []
 includeSuitePatterns:
-  - "lp-interop%"
+  - "lp-chaos--%"
+  - "lp-interop--%"
+  - "lp-ocp-compat--%"
 excludeSuitePatterns: []
 excludeTests:
   - "Build image%"

--- a/pkg/bigquery/test_table_test.go
+++ b/pkg/bigquery/test_table_test.go
@@ -27,17 +27,17 @@ func TestBuildSuitesFilter(t *testing.T) {
 		{
 			name: "include patterns only",
 			config: &v1.Config{
-				IncludeSuitePatterns: []string{"lp-interop%", "e2e-%"},
+				IncludeSuitePatterns: []string{"lp-interop--%", "e2e-%"},
 			},
-			want: "(testsuite LIKE 'lp-interop%' OR testsuite LIKE 'e2e-%')",
+			want: "(testsuite LIKE 'lp-interop--%' OR testsuite LIKE 'e2e-%')",
 		},
 		{
 			name: "include exact and patterns",
 			config: &v1.Config{
 				IncludeSuites:        []string{"openshift-tests"},
-				IncludeSuitePatterns: []string{"lp-interop%"},
+				IncludeSuitePatterns: []string{"lp-interop--%"},
 			},
-			want: "(testsuite IN ('openshift-tests') OR testsuite LIKE 'lp-interop%')",
+			want: "(testsuite IN ('openshift-tests') OR testsuite LIKE 'lp-interop--%')",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/components/acslatestlpinterop/component.go
+++ b/pkg/components/acslatestlpinterop/component.go
@@ -18,9 +18,9 @@ var ACSLatestLpInteropComponent = Component{
 		DefaultJiraComponent: "ACS-lp-interop",
 		Matchers: []config.ComponentMatcher{
 			{Suite: "ACSLatest-lp-interop"},
-			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--ACSLatest--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--ACSLatest--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--ACSLatest--`)},
 		},
 	},
 }

--- a/pkg/components/acslatestlpinterop/component.go
+++ b/pkg/components/acslatestlpinterop/component.go
@@ -1,6 +1,8 @@
 package acslatestlpinterop
 
 import (
+	"regexp"
+
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
 )
@@ -14,7 +16,12 @@ var ACSLatestLpInteropComponent = Component{
 		Name:                 "ACSLatest-lp-interop",
 		Operators:            []string{},
 		DefaultJiraComponent: "ACS-lp-interop",
-		Matchers:             []config.ComponentMatcher{{Suite: "ACSLatest-lp-interop"}},
+		Matchers: []config.ComponentMatcher{
+			{Suite: "ACSLatest-lp-interop"},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+		},
 	},
 }
 

--- a/pkg/components/acslpinterop/component.go
+++ b/pkg/components/acslpinterop/component.go
@@ -18,9 +18,9 @@ var ACSLpInteropComponent = Component{
 		DefaultJiraComponent: "ACS-lp-interop",
 		Matchers: []config.ComponentMatcher{
 			{Suite: "ACS-lp-interop"},
-			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--ACS--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--ACS--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--ACS--`)},
 		},
 	},
 }

--- a/pkg/components/acslpinterop/component.go
+++ b/pkg/components/acslpinterop/component.go
@@ -1,6 +1,8 @@
 package acslpinterop
 
 import (
+	"regexp"
+
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
 )
@@ -14,7 +16,12 @@ var ACSLpInteropComponent = Component{
 		Name:                 "ACS-lp-interop",
 		Operators:            []string{},
 		DefaultJiraComponent: "ACS-lp-interop",
-		Matchers:             []config.ComponentMatcher{{Suite: "ACS-lp-interop"}},
+		Matchers: []config.ComponentMatcher{
+			{Suite: "ACS-lp-interop"},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+		},
 	},
 }
 

--- a/pkg/components/cnvlpinterop/component.go
+++ b/pkg/components/cnvlpinterop/component.go
@@ -1,6 +1,8 @@
 package cnvlpinterop
 
 import (
+	"regexp"
+
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
 )
@@ -14,7 +16,12 @@ var CNVLpInteropComponent = Component{
 		Name:                 "CNV-lp-interop",
 		Operators:            []string{},
 		DefaultJiraComponent: "CNV-lp-interop",
-		Matchers:             []config.ComponentMatcher{{Suite: "CNV-lp-interop"}},
+		Matchers: []config.ComponentMatcher{
+			{Suite: "CNV-lp-interop"},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+		},
 	},
 }
 

--- a/pkg/components/cnvlpinterop/component.go
+++ b/pkg/components/cnvlpinterop/component.go
@@ -18,9 +18,9 @@ var CNVLpInteropComponent = Component{
 		DefaultJiraComponent: "CNV-lp-interop",
 		Matchers: []config.ComponentMatcher{
 			{Suite: "CNV-lp-interop"},
-			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--CNV--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--CNV--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--CNV--`)},
 		},
 	},
 }

--- a/pkg/components/fusionaccesslpinterop/component.go
+++ b/pkg/components/fusionaccesslpinterop/component.go
@@ -18,9 +18,9 @@ var FusionAccessLpInteropComponent = Component{
 		DefaultJiraComponent: "Fusion-access-lp-interop",
 		Matchers: []config.ComponentMatcher{
 			{Suite: "Fusion-access-lp-interop"},
-			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--Fusion-access--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--Fusion-access--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--Fusion-access--`)},
 		},
 	},
 }

--- a/pkg/components/fusionaccesslpinterop/component.go
+++ b/pkg/components/fusionaccesslpinterop/component.go
@@ -1,6 +1,8 @@
 package fusionaccesslpinterop
 
 import (
+	"regexp"
+
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
 )
@@ -14,7 +16,12 @@ var FusionAccessLpInteropComponent = Component{
 		Name:                 "Fusion-access-lp-interop",
 		Operators:            []string{},
 		DefaultJiraComponent: "Fusion-access-lp-interop",
-		Matchers:             []config.ComponentMatcher{{Suite: "Fusion-access-lp-interop"}},
+		Matchers: []config.ComponentMatcher{
+			{Suite: "Fusion-access-lp-interop"},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+		},
 	},
 }
 

--- a/pkg/components/gitopslpinterop/component.go
+++ b/pkg/components/gitopslpinterop/component.go
@@ -1,6 +1,8 @@
 package gitopslpinterop
 
 import (
+	"regexp"
+
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
 )
@@ -14,7 +16,12 @@ var GitopsLpInteropComponent = Component{
 		Name:                 "Gitops-lp-interop",
 		Operators:            []string{},
 		DefaultJiraComponent: "Gitops-lp-interop",
-		Matchers:             []config.ComponentMatcher{{Suite: "Gitops-lp-interop"}},
+		Matchers: []config.ComponentMatcher{
+			{Suite: "Gitops-lp-interop"},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+		},
 	},
 }
 

--- a/pkg/components/gitopslpinterop/component.go
+++ b/pkg/components/gitopslpinterop/component.go
@@ -18,9 +18,9 @@ var GitopsLpInteropComponent = Component{
 		DefaultJiraComponent: "Gitops-lp-interop",
 		Matchers: []config.ComponentMatcher{
 			{Suite: "Gitops-lp-interop"},
-			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--Gitops--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--Gitops--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--Gitops--`)},
 		},
 	},
 }

--- a/pkg/components/mtalpinterop/component.go
+++ b/pkg/components/mtalpinterop/component.go
@@ -18,9 +18,9 @@ var MTALpInteropComponent = Component{
 		DefaultJiraComponent: "MTA-lp-interop",
 		Matchers: []config.ComponentMatcher{
 			{Suite: "MTA-lp-interop"},
-			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--MTA--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--MTA--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--MTA--`)},
 		},
 	},
 }

--- a/pkg/components/mtalpinterop/component.go
+++ b/pkg/components/mtalpinterop/component.go
@@ -1,6 +1,8 @@
 package mtalpinterop
 
 import (
+	"regexp"
+
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
 )
@@ -14,7 +16,12 @@ var MTALpInteropComponent = Component{
 		Name:                 "MTA-lp-interop",
 		Operators:            []string{},
 		DefaultJiraComponent: "MTA-lp-interop",
-		Matchers:             []config.ComponentMatcher{{Suite: "MTA-lp-interop"}},
+		Matchers: []config.ComponentMatcher{
+			{Suite: "MTA-lp-interop"},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+		},
 	},
 }
 

--- a/pkg/components/oadplpinterop/component.go
+++ b/pkg/components/oadplpinterop/component.go
@@ -1,6 +1,8 @@
 package oadplpinterop
 
 import (
+	"regexp"
+
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
 )
@@ -14,7 +16,12 @@ var OADPLpInteropComponent = Component{
 		Name:                 "OADP-lp-interop",
 		Operators:            []string{},
 		DefaultJiraComponent: "OADP-lp-interop",
-		Matchers:             []config.ComponentMatcher{{Suite: "OADP-lp-interop"}},
+		Matchers: []config.ComponentMatcher{
+			{Suite: "OADP-lp-interop"},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+		},
 	},
 }
 

--- a/pkg/components/oadplpinterop/component.go
+++ b/pkg/components/oadplpinterop/component.go
@@ -18,9 +18,9 @@ var OADPLpInteropComponent = Component{
 		DefaultJiraComponent: "OADP-lp-interop",
 		Matchers: []config.ComponentMatcher{
 			{Suite: "OADP-lp-interop"},
-			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--OADP--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--OADP--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--OADP--`)},
 		},
 	},
 }

--- a/pkg/components/odflpinterop/component.go
+++ b/pkg/components/odflpinterop/component.go
@@ -1,6 +1,8 @@
 package odflpinterop
 
 import (
+	"regexp"
+
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
 )
@@ -14,7 +16,12 @@ var ODFLpInteropComponent = Component{
 		Name:                 "ODF-lp-interop",
 		Operators:            []string{},
 		DefaultJiraComponent: "ODF-lp-interop",
-		Matchers:             []config.ComponentMatcher{{Suite: "ODF-lp-interop"}},
+		Matchers: []config.ComponentMatcher{
+			{Suite: "ODF-lp-interop"},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+		},
 	},
 }
 

--- a/pkg/components/odflpinterop/component.go
+++ b/pkg/components/odflpinterop/component.go
@@ -18,9 +18,9 @@ var ODFLpInteropComponent = Component{
 		DefaultJiraComponent: "ODF-lp-interop",
 		Matchers: []config.ComponentMatcher{
 			{Suite: "ODF-lp-interop"},
-			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--ODF--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--ODF--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--ODF--`)},
 		},
 	},
 }

--- a/pkg/components/openshiftpipelineslpinterop/component.go
+++ b/pkg/components/openshiftpipelineslpinterop/component.go
@@ -16,7 +16,12 @@ var OpenshiftPipelinesLpInteropComponent = Component{
 		Name:                 "Openshift-pipelines-lp-interop",
 		Operators:            []string{},
 		DefaultJiraComponent: "Openshift-pipelines-lp-interop",
-		Matchers:             []config.ComponentMatcher{{Suite: "OpenshiftPipelines-lp-interop", SuiteRegEx: regexp.MustCompile("^lp-interop-OpenshiftPipelines.*")}},
+		Matchers: []config.ComponentMatcher{
+			{Suite: "OpenshiftPipelines-lp-interop"},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+		},
 	},
 }
 

--- a/pkg/components/openshiftpipelineslpinterop/component.go
+++ b/pkg/components/openshiftpipelineslpinterop/component.go
@@ -18,9 +18,10 @@ var OpenshiftPipelinesLpInteropComponent = Component{
 		DefaultJiraComponent: "Openshift-pipelines-lp-interop",
 		Matchers: []config.ComponentMatcher{
 			{Suite: "OpenshiftPipelines-lp-interop"},
-			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+			{SuiteRegEx: regexp.MustCompile("^lp-interop-OpenshiftPipelines--")}, //To be removed
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--OpenshiftPipelines--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--OpenshiftPipelines--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--OpenshiftPipelines--`)},
 		},
 	},
 }

--- a/pkg/components/openshiftpipelineslpinterop/component.go
+++ b/pkg/components/openshiftpipelineslpinterop/component.go
@@ -18,7 +18,7 @@ var OpenshiftPipelinesLpInteropComponent = Component{
 		DefaultJiraComponent: "Openshift-pipelines-lp-interop",
 		Matchers: []config.ComponentMatcher{
 			{Suite: "OpenshiftPipelines-lp-interop"},
-			{SuiteRegEx: regexp.MustCompile("^lp-interop-OpenshiftPipelines--")}, //To be removed
+			{SuiteRegEx: regexp.MustCompile("^lp-interop-OpenshiftPipelines--")}, // To be removed
 			{SuiteRegEx: regexp.MustCompile(`^lp-interop--OpenshiftPipelines--`)},
 			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--OpenshiftPipelines--`)},
 			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--OpenshiftPipelines--`)},

--- a/pkg/components/quaylpinterop/component.go
+++ b/pkg/components/quaylpinterop/component.go
@@ -18,9 +18,9 @@ var QuayLpInteropComponent = Component{
 		DefaultJiraComponent: "Quay-lp-interop",
 		Matchers: []config.ComponentMatcher{
 			{Suite: "Quay-lp-interop"},
-			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--Quay--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--Quay--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--Quay--`)},
 		},
 	},
 }

--- a/pkg/components/quaylpinterop/component.go
+++ b/pkg/components/quaylpinterop/component.go
@@ -1,6 +1,8 @@
 package quaylpinterop
 
 import (
+	"regexp"
+
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
 )
@@ -14,7 +16,12 @@ var QuayLpInteropComponent = Component{
 		Name:                 "Quay-lp-interop",
 		Operators:            []string{},
 		DefaultJiraComponent: "Quay-lp-interop",
-		Matchers:             []config.ComponentMatcher{{Suite: "Quay-lp-interop"}},
+		Matchers: []config.ComponentMatcher{
+			{Suite: "Quay-lp-interop"},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+		},
 	},
 }
 

--- a/pkg/components/serverlesslpinterop/component.go
+++ b/pkg/components/serverlesslpinterop/component.go
@@ -18,9 +18,9 @@ var ServerlessLpInteropComponent = Component{
 		DefaultJiraComponent: "Serverless-lp-interop",
 		Matchers: []config.ComponentMatcher{
 			{Suite: "Serverless-lp-interop"},
-			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--Serverless--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--Serverless--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--Serverless--`)},
 		},
 	},
 }

--- a/pkg/components/serverlesslpinterop/component.go
+++ b/pkg/components/serverlesslpinterop/component.go
@@ -1,6 +1,8 @@
 package serverlesslpinterop
 
 import (
+	"regexp"
+
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
 )
@@ -14,7 +16,12 @@ var ServerlessLpInteropComponent = Component{
 		Name:                 "Serverless-lp-interop",
 		Operators:            []string{},
 		DefaultJiraComponent: "Serverless-lp-interop",
-		Matchers:             []config.ComponentMatcher{{Suite: "Serverless-lp-interop"}},
+		Matchers: []config.ComponentMatcher{
+			{Suite: "Serverless-lp-interop"},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+		},
 	},
 }
 

--- a/pkg/components/servicemeshlpinterop/component.go
+++ b/pkg/components/servicemeshlpinterop/component.go
@@ -1,6 +1,8 @@
 package servicemeshlpinterop
 
 import (
+	"regexp"
+
 	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
 	"github.com/openshift-eng/ci-test-mapping/pkg/config"
 )
@@ -14,7 +16,12 @@ var ServiceMeshLpInteropComponent = Component{
 		Name:                 "Service-mesh-lp-interop",
 		Operators:            []string{},
 		DefaultJiraComponent: "Service-mesh-lp-interop",
-		Matchers:             []config.ComponentMatcher{{Suite: "ServiceMesh-lp-interop"}},
+		Matchers: []config.ComponentMatcher{
+			{Suite: "ServiceMesh-lp-interop"},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+		},
 	},
 }
 

--- a/pkg/components/servicemeshlpinterop/component.go
+++ b/pkg/components/servicemeshlpinterop/component.go
@@ -18,9 +18,9 @@ var ServiceMeshLpInteropComponent = Component{
 		DefaultJiraComponent: "Service-mesh-lp-interop",
 		Matchers: []config.ComponentMatcher{
 			{Suite: "ServiceMesh-lp-interop"},
-			{SuiteRegEx: regexp.MustCompile(`^lp-interop--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--`)},
-			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--ServiceMesh--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--ServiceMesh--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--ServiceMesh--`)},
 		},
 	},
 }


### PR DESCRIPTION
Following #648, this PR aligns `includeSuitePatterns` with component suite matchers registered by the MPEX org, by adding the following `SuiteRegEx` entries:

- `lp-interop--<lpName>--`
- `lp-chaos--<lpName>--`
- `lp-ocp-compat--<lpName>--`

(consistent with `config/openshift-eng.yaml`).

Minor test naming / example updates in `pkg/bigquery/test_table_test.go` for suite pattern
fixtures.
<!--

Thanks for contributing to ci-test-mapping.

Please make sure to run `make mapping` and commit the results when
making changes to test ownership. To have your PR's tested
automatically, join the openshift-eng GitHub organization. See the
instructions on #forum-pge-cloud-ops on Slack.

Please see README.md for additional information how about
this repo works.

-->
