### PR TITLE
TRT-2621: 🤖 Enable Git LFS for large data files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 data/** linguist-generated
+data/**/*.json filter=lfs diff=lfs merge=lfs -text

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,10 @@ ENV PATH="/go/bin:${PATH}"
 ENV GOPATH="/go"
 RUN dnf install -y \
         git \
+        git-lfs \
         go \
         make
+RUN git lfs install
 RUN go install k8s.io/test-infra/robots/pr-creator@latest
 # install gh-token before it required go 1.23 which ubi9 doesn't have yet;
 # unfortunately `go install` with the tag is broken, so just clone and install.
@@ -15,7 +17,8 @@ COPY . .
 RUN make build
 
 FROM registry.access.redhat.com/ubi9/ubi:latest AS base
-RUN dnf install -y git jq
+RUN dnf install -y git git-lfs jq
+RUN git lfs install
 COPY --from=builder /go/src/openshift-eng/ci-test-mapping/ci-test-mapping /bin/ci-test-mapping
 COPY --from=builder /go/bin/gh-token /bin/gh-token
 COPY --from=builder /go/bin/pr-creator /bin/pr-creator

--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -9,8 +9,10 @@ RUN curl -Lso /tmp/golangci-lint.rpm \
           "https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-amd64.rpm" && \
       dnf install -y \
         git \
+        git-lfs \
         go \
         make \
         /tmp/golangci-lint.rpm && \
       rm /tmp/golangci-lint.rpm && \
+      git lfs install && \
       go install gotest.tools/gotestsum@latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,50 @@
 # Component Readiness Test Mapping
 
+## Prerequisites
+
+This repository uses [Git Large File Storage (LFS)](https://git-lfs.github.com/) to manage large data files. You must have Git LFS installed and configured before cloning or working with this repository.
+
+### Installing Git LFS
+
+**Fedora/RHEL/CentOS:**
+```bash
+sudo dnf install git-lfs
+```
+
+**Ubuntu/Debian:**
+```bash
+sudo apt-get install git-lfs
+```
+
+**macOS (with Homebrew):**
+```bash
+brew install git-lfs
+```
+
+**Windows:**
+Download from https://git-lfs.github.com/ or use:
+```bash
+winget install GitHub.GitLFS
+```
+
+### Initial Setup
+
+After installing Git LFS, run this command once:
+```bash
+git lfs install
+```
+
+Then clone the repository as usual:
+```bash
+git clone https://github.com/openshift-eng/ci-test-mapping.git
+```
+
+If you already have the repository cloned, run `git lfs pull` to download the LFS files.
+
+**Note:** GitHub provides 1 GB of free LFS storage and 1 GB/month of bandwidth per account. Large files in the `data/` directory are tracked with LFS to avoid hitting Git's 100 MB file size limit.
+
+## Overview
+
 Component Readiness needs to know how to map each test to a particular
 component and its capabilities. This tool:
 


### PR DESCRIPTION
Mapping JSON files have grown to 94MB, exceeding the 50MB soft limit. Configure Git LFS to track JSON files in the data/ directory to prevent hitting GitHub's 100MB file size limit.

Changes:
- Add .gitattributes to track data/**/*.json with Git LFS
- Update Dockerfile to install git-lfs in both builder and runtime stages
- Update Dockerfile.buildroot to install git-lfs for CI builds
- Add Prerequisites section to README.md with Git LFS setup instructions

This enables the repository to handle files larger than GitHub's limits without requiring history rewrites or disruptive migrations.

🤖 Assisted by Claude Code

<!--

Thanks for contributing to ci-test-mapping.

Please make sure to run `make mapping` and commit the results when
making changes to test ownership. To have your PR's tested
automatically, join the openshift-eng GitHub organization. See the
instructions on #forum-pge-cloud-ops on Slack.

Please see README.md for additional information how about
this repo works.

-->
