### PR TITLE
Add MPEXOperator LP interop component mapping

### DIFF
--- a/pkg/components/mpexoperatorlpinterop/capabilities.go
+++ b/pkg/components/mpexoperatorlpinterop/capabilities.go
@@ -1,0 +1,12 @@
+package mpexoperatorlpinterop
+
+import (
+	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
+	"github.com/openshift-eng/ci-test-mapping/pkg/util"
+)
+
+func identifyCapabilities(test *v1.TestInfo) []string {
+	capabilities := util.DefaultCapabilities(test)
+
+	return capabilities
+}

--- a/pkg/components/mpexoperatorlpinterop/component.go
+++ b/pkg/components/mpexoperatorlpinterop/component.go
@@ -1,0 +1,60 @@
+package mpexoperatorlpinterop
+
+import (
+	"regexp"
+
+	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
+	"github.com/openshift-eng/ci-test-mapping/pkg/config"
+)
+
+type Component struct {
+	*config.Component
+}
+
+var MPEXOperatorLpInteropComponent = Component{
+	Component: &config.Component{
+		Name:                 "MPEXOperator-lp-interop",
+		Operators:            []string{},
+		DefaultJiraComponent: "MPEXOperator",
+		Matchers: []config.ComponentMatcher{
+			{Suite: "MPEXOperator-lp-interop"},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--MPEXOperator--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--MPEXOperator--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--MPEXOperator--`)},
+		},
+	},
+}
+
+func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
+	if matcher := c.FindMatch(test); matcher != nil {
+		jira := matcher.JiraComponent
+		if jira == "" {
+			jira = c.DefaultJiraComponent
+		}
+		return &v1.TestOwnership{
+			Name:          test.Name,
+			Component:     c.Name,
+			JIRAComponent: jira,
+			Priority:      matcher.Priority,
+			Capabilities:  append(matcher.Capabilities, identifyCapabilities(test)...),
+		}, nil
+	}
+
+	return nil, nil
+}
+
+func (c *Component) StableID(test *v1.TestInfo) string {
+	if stableName, ok := c.TestRenames[test.Name]; ok {
+		return stableName
+	}
+	return test.Name
+}
+
+func (c *Component) JiraComponents() (components []string) {
+	components = []string{c.DefaultJiraComponent}
+	for _, m := range c.Matchers {
+		components = append(components, m.JiraComponent)
+	}
+
+	return components
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -113,6 +113,7 @@ import (
 	microshiftnetworking "github.com/openshift-eng/ci-test-mapping/pkg/components/microshift/networking"
 	microshiftstorage "github.com/openshift-eng/ci-test-mapping/pkg/components/microshift/storage"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/monitoring"
+	"github.com/openshift-eng/ci-test-mapping/pkg/components/mpexoperatorlpinterop"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/mtalpinterop"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/multiarch"
 	multiarcharm "github.com/openshift-eng/ci-test-mapping/pkg/components/multiarch/arm"
@@ -462,6 +463,7 @@ func NewComponentRegistry() *Registry {
 	r.Register("ServiceMesh-lp-interop", &servicemeshlpinterop.ServiceMeshLpInteropComponent)
 	r.Register("Serverless-lp-interop", &serverlesslpinterop.ServerlessLpInteropComponent)
 	r.Register("ODF-lp-interop", &odflpinterop.ODFLpInteropComponent)
+	r.Register("MPEXOperator-lp-interop", &mpexoperatorlpinterop.MPEXOperatorLpInteropComponent)
 	r.Register("MTA-lp-interop", &mtalpinterop.MTALpInteropComponent)
 	r.Register("Gitops-lp-interop", &gitopslpinterop.GitopsLpInteropComponent)
 	r.Register("ACSLatest-lp-interop", &acslatestlpinterop.ACSLatestLpInteropComponent)


### PR DESCRIPTION
## Summary
- Add `pkg/components/mpexoperatorlpinterop` with matchers for `lp-ocp-compat--MPEXOperator--`, `lp-interop--MPEXOperator--`, `lp-chaos--MPEXOperator--`
- Register `MPEXOperator-lp-interop` in `pkg/registry/registry.go`

## Identifiers
| Field | Value |
|-------|-------|
| Component Name | `MPEXOperator-lp-interop` |
| DefaultJiraComponent | `MPEXOperator` |
| Mapped suite prefix | `lp-ocp-compat--MPEXOperator` |

## Related PRs
- openshift/sippy: (link after sippy PR is created)

## Maintainer steps (requester)
Before merge:
```bash
make mapping
./ci-test-mapping jira-verify
```

## Source
[ocp-ci-docs] LP_Interop_CR_Agent_Playbook


Made with [Cursor](https://cursor.com)