### PR TITLE
[WIP] SPIKE: Onboard LPComp for LP Interop Component Readiness (ci-test-mapping)

### DIFF
--- a/pkg/components/lpcomplpinterop/capabilities.go
+++ b/pkg/components/lpcomplpinterop/capabilities.go
@@ -1,0 +1,12 @@
+package lpcomplpinterop
+
+import (
+	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
+	"github.com/openshift-eng/ci-test-mapping/pkg/util"
+)
+
+func identifyCapabilities(test *v1.TestInfo) []string {
+	capabilities := util.DefaultCapabilities(test)
+
+	return capabilities
+}

--- a/pkg/components/lpcomplpinterop/component.go
+++ b/pkg/components/lpcomplpinterop/component.go
@@ -1,0 +1,60 @@
+package lpcomplpinterop
+
+import (
+	"regexp"
+
+	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
+	"github.com/openshift-eng/ci-test-mapping/pkg/config"
+)
+
+type Component struct {
+	*config.Component
+}
+
+var LPCompLpInteropComponent = Component{
+	Component: &config.Component{
+		Name:                 "LPComp-lp-interop",
+		Operators:            []string{},
+		DefaultJiraComponent: "LPComp",
+		Matchers: []config.ComponentMatcher{
+			{Suite: "LPComp-lp-interop"},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--LPComp--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--LPComp--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--LPComp--`)},
+		},
+	},
+}
+
+func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
+	if matcher := c.FindMatch(test); matcher != nil {
+		jira := matcher.JiraComponent
+		if jira == "" {
+			jira = c.DefaultJiraComponent
+		}
+		return &v1.TestOwnership{
+			Name:          test.Name,
+			Component:     c.Name,
+			JIRAComponent: jira,
+			Priority:      matcher.Priority,
+			Capabilities:  append(matcher.Capabilities, identifyCapabilities(test)...),
+		}, nil
+	}
+
+	return nil, nil
+}
+
+func (c *Component) StableID(test *v1.TestInfo) string {
+	if stableName, ok := c.TestRenames[test.Name]; ok {
+		return stableName
+	}
+	return test.Name
+}
+
+func (c *Component) JiraComponents() (components []string) {
+	components = []string{c.DefaultJiraComponent}
+	for _, m := range c.Matchers {
+		components = append(components, m.JiraComponent)
+	}
+
+	return components
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -101,6 +101,7 @@ import (
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/logging"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/logicalvolumemanagerstorage"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/lowlatencyvalidationtooling"
+	"github.com/openshift-eng/ci-test-mapping/pkg/components/lpcomplpinterop"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/machineconfigoperator"
 	machineconfigoperatorplatformbaremetal "github.com/openshift-eng/ci-test-mapping/pkg/components/machineconfigoperator/platformbaremetal"
 	machineconfigoperatorplatformnone "github.com/openshift-eng/ci-test-mapping/pkg/components/machineconfigoperator/platformnone"
@@ -464,6 +465,7 @@ func NewComponentRegistry() *Registry {
 	r.Register("ODF-lp-interop", &odflpinterop.ODFLpInteropComponent)
 	r.Register("MTA-lp-interop", &mtalpinterop.MTALpInteropComponent)
 	r.Register("Gitops-lp-interop", &gitopslpinterop.GitopsLpInteropComponent)
+	r.Register("LPComp-lp-interop", &lpcomplpinterop.LPCompLpInteropComponent)
 	r.Register("ACSLatest-lp-interop", &acslatestlpinterop.ACSLatestLpInteropComponent)
 	r.Register("ACS-lp-interop", &acslpinterop.ACSLpInteropComponent)
 	r.Register("OADP-lp-interop", &oadplpinterop.OADPLpInteropComponent)


### PR DESCRIPTION
## Summary

Onboard **LPComp** for LP Interop Component Readiness (ci-test-mapping).

| Identifier | Value |
|------------|-------|
| Component name | `LPComp-lp-interop` |
| DefaultJiraComponent | `LPComp` |
| Mapped suite prefixes | `lp-ocp-compat--LPComp--`, `lp-interop--LPComp--`, `lp-chaos--LPComp--` |
| LayeredProduct (Sippy) | `lp-interop-lpcomp` |

### Changes

- `pkg/components/lpcomplpinterop/component.go` — new component
- `pkg/components/lpcomplpinterop/capabilities.go` — `identifyCapabilities` via `util.DefaultCapabilities`
- `pkg/registry/registry.go` — import + `r.Register("LPComp-lp-interop", ...)`
- `config/openshift-eng.yaml`: **no change** — `lp-ocp-compat--%` already in `includeSuitePatterns`

### Related PRs

- openshift/sippy: https://github.com/openshift/sippy/pull/3549

### Maintainer `make`

`make mapping` was run successfully in the agent environment.

Source: [ocp-ci-docs] LP_Interop_CR_Agent_Playbook
