### PR TITLE
TRT-2658: reduce json file size

### DIFF
--- a/pkg/api/types/v1/component.go
+++ b/pkg/api/types/v1/component.go
@@ -37,9 +37,11 @@ type TestInfo struct {
 	Suite string `bigquery:"suite"`
 
 	// Variants contains the set of all job variants this test appeared in.  This is useful
-	// for assinging components and capabilities. For example, all tests with `Procedure:etcd-scaling`
+	// for assigning components and capabilities. For example, all tests with `Procedure:etcd-scaling`
 	// could be assigned to the `etcd` component.
-	Variants []string `bigquery:"variants"`
+	// Because including this makes junit.json much larger and nothing relies on that
+	// serialized form, we exclude it from the json serialization.
+	Variants []string `bigquery:"variants" json:"-"`
 }
 
 const TestOwnershipAPIVersion = "v1"


### PR DESCRIPTION
`data/openshift-gce-devel/ci_analysis_us/junit.json` is too huge and we don't believe we need the variants serialized here.

<!--

Thanks for contributing to ci-test-mapping.

Please make sure to run `make mapping` and commit the results when
making changes to test ownership. To have your PR's tested
automatically, join the openshift-eng GitHub organization. See the
instructions on #forum-pge-cloud-ops on Slack.

Please see README.md for additional information how about
this repo works.

-->
