### PR TITLE
followup linter updates

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -105,7 +105,7 @@ linters:
       - builtin$
       - examples$
     rules:
-      - path: 'pkg/components/build/component\.go'
+      - path: 'pkg/components/build/'
         linters:
           - revive
         text: 'var-naming.*package names that conflict'

--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -5,12 +5,9 @@
 #
 FROM registry.access.redhat.com/ubi9/ubi:latest
 ARG GOLANGCI_LINT_VERSION="2.10.1"
-RUN curl -Lso /tmp/golangci-lint.rpm \
-          "https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-amd64.rpm" && \
-      dnf install -y \
+RUN dnf install -y \
         git \
         go \
         make \
-        /tmp/golangci-lint.rpm && \
-      rm /tmp/golangci-lint.rpm && \
-      go install gotest.tools/gotestsum@latest
+    && GOBIN=/usr/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${GOLANGCI_LINT_VERSION} \
+    && GOBIN=/usr/bin go install gotest.tools/gotestsum@latest


### PR DESCRIPTION
* have the linter built using the installed golang so it can't get behind
* widen a linter exclusion so it doesn't flake

explained further in the commit msgs