### PR TITLE
INTEROP-9273: Add LP--OPP component for Sippy/TestGrid integration

### DIFF
--- a/pkg/components/lpopp/capabilities.go
+++ b/pkg/components/lpopp/capabilities.go
@@ -1,0 +1,12 @@
+package lpopp
+
+import (
+	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
+	"github.com/openshift-eng/ci-test-mapping/pkg/util"
+)
+
+func identifyCapabilities(test *v1.TestInfo) []string {
+	capabilities := util.DefaultCapabilities(test)
+
+	return capabilities
+}

--- a/pkg/components/lpopp/component.go
+++ b/pkg/components/lpopp/component.go
@@ -1,0 +1,61 @@
+package lpopp
+
+import (
+	"regexp"
+
+	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
+	"github.com/openshift-eng/ci-test-mapping/pkg/config"
+)
+
+type Component struct {
+	*config.Component
+}
+
+var LPoppComponent = Component{
+	Component: &config.Component{
+		Name:                 "LP--OPP",
+		Operators:            []string{},
+		DefaultJiraComponent: "LP--OPP",
+		Matchers: []config.ComponentMatcher{
+			{Suite: "OPP-lp-interop"},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--OPP--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--OPP--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--OPP--`)},
+		},
+	},
+}
+
+func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
+	if matcher := c.FindMatch(test); matcher != nil {
+		jira := matcher.JiraComponent
+		if jira == "" {
+			jira = c.DefaultJiraComponent
+		}
+		return &v1.TestOwnership{
+			Name:          test.Name,
+			Component:     c.Name,
+			JIRAComponent: jira,
+			Priority:      matcher.Priority,
+			Capabilities:  append(matcher.Capabilities, identifyCapabilities(test)...),
+		}, nil
+	}
+
+	return nil, nil
+}
+
+func (c *Component) StableID(test *v1.TestInfo) string {
+	// Look up the stable name for our test in our renamed tests map.
+	if stableName, ok := c.TestRenames[test.Name]; ok {
+		return stableName
+	}
+	return test.Name
+}
+
+func (c *Component) JiraComponents() (components []string) {
+	components = []string{c.DefaultJiraComponent}
+	for _, m := range c.Matchers {
+		components = append(components, m.JiraComponent)
+	}
+
+	return components
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -104,6 +104,7 @@ import (
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/lpoadp"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/lpodf"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/lpopenshiftpipelines"
+	"github.com/openshift-eng/ci-test-mapping/pkg/components/lpopp"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/lpquay"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/lpserverless"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/lpservicemesh"
@@ -465,6 +466,7 @@ func NewComponentRegistry() *Registry {
 	r.Register("LP--ACS", &lpacs.LPacsComponent)
 	r.Register("LP--OADP", &lpoadp.LPoadpComponent)
 	r.Register("LP--Fusion-access", &lpfusionaccess.LPfusionaccessComponent)
+	r.Register("LP--OPP", &lpopp.LPoppComponent)
 	// New components go here
 
 	return &r


### PR DESCRIPTION
Register the new LP--OPP layered product component with matchers for OPP-lp-interop suite and lp-chaos/interop/ocp-compat regex patterns, following the established LP component pattern (LP--ACS, LP--CNV, etc.).

Regenerated component_mapping.json via make mapping.

Ref: [INTEROP-9273](https://redhat.atlassian.net/browse/INTEROP-9273)
