### PR TITLE
INTEROP-9256: Add LP--ACM component for ACM+Virt interop CR test mapping

### DIFF
--- a/pkg/components/lpacm/capabilities.go
+++ b/pkg/components/lpacm/capabilities.go
@@ -1,0 +1,12 @@
+package lpacm
+
+import (
+	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
+	"github.com/openshift-eng/ci-test-mapping/pkg/util"
+)
+
+func identifyCapabilities(test *v1.TestInfo) []string {
+	capabilities := util.DefaultCapabilities(test)
+
+	return capabilities
+}

--- a/pkg/components/lpacm/component.go
+++ b/pkg/components/lpacm/component.go
@@ -1,0 +1,62 @@
+package lpacm
+
+import (
+	"regexp"
+
+	v1 "github.com/openshift-eng/ci-test-mapping/pkg/api/types/v1"
+	"github.com/openshift-eng/ci-test-mapping/pkg/config"
+)
+
+type Component struct {
+	*config.Component
+}
+
+var LPacmComponent = Component{
+	Component: &config.Component{
+		Name:                 "LP--ACM",
+		Operators:            []string{},
+		DefaultJiraComponent: "LP--ACM",
+		Matchers: []config.ComponentMatcher{
+			{Suite: "ACM-lp-interop"},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--ACM-Virt--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--ACM--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-chaos--ACM--`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-ocp-compat--ACM--`)},
+		},
+	},
+}
+
+func (c *Component) IdentifyTest(test *v1.TestInfo) (*v1.TestOwnership, error) {
+	if matcher := c.FindMatch(test); matcher != nil {
+		jira := matcher.JiraComponent
+		if jira == "" {
+			jira = c.DefaultJiraComponent
+		}
+		return &v1.TestOwnership{
+			Name:          test.Name,
+			Component:     c.Name,
+			JIRAComponent: jira,
+			Priority:      matcher.Priority,
+			Capabilities:  append(matcher.Capabilities, identifyCapabilities(test)...),
+		}, nil
+	}
+
+	return nil, nil
+}
+
+func (c *Component) StableID(test *v1.TestInfo) string {
+	// Look up the stable name for our test in our renamed tests map.
+	if stableName, ok := c.TestRenames[test.Name]; ok {
+		return stableName
+	}
+	return test.Name
+}
+
+func (c *Component) JiraComponents() (components []string) {
+	components = []string{c.DefaultJiraComponent}
+	for _, m := range c.Matchers {
+		components = append(components, m.JiraComponent)
+	}
+
+	return components
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -96,6 +96,7 @@ import (
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/logging"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/logicalvolumemanagerstorage"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/lowlatencyvalidationtooling"
+	"github.com/openshift-eng/ci-test-mapping/pkg/components/lpacm"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/lpacs"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/lpcnv"
 	"github.com/openshift-eng/ci-test-mapping/pkg/components/lpfusionaccess"
@@ -463,6 +464,7 @@ func NewComponentRegistry() *Registry {
 	r.Register("LP--ODF", &lpodf.LPodfComponent)
 	r.Register("LP--MTA", &lpmta.LPmtaComponent)
 	r.Register("LP--Gitops", &lpgitops.LPgitopsComponent)
+	r.Register("LP--ACM", &lpacm.LPacmComponent)
 	r.Register("LP--ACS", &lpacs.LPacsComponent)
 	r.Register("LP--OADP", &lpoadp.LPoadpComponent)
 	r.Register("LP--Fusion-access", &lpfusionaccess.LPfusionaccessComponent)


### PR DESCRIPTION
## Summary

Add a new `LP--ACM` component to route ACM and ACM+Virt interop test suites to the `LP--ACM` Component Readiness component in OCPBUGS.

## Changed Files
- `pkg/components/lpacm/component.go` — Component definition with matchers
- `pkg/components/lpacm/capabilities.go` — Default capabilities
- `pkg/registry/registry.go` — Import + `r.Register("LP--ACM", ...)`

## Matchers
| Matcher | Purpose |
|---------|---------|
| `{Suite: "ACM-lp-interop"}` | Legacy exact suite name |
| `^lp-interop--ACM-Virt--` | Combined ACM+Virt P2P jobs (`DR__RP__CR_COMP_NAME: lp-interop--ACM-Virt`) |
| `^lp-interop--ACM--` | Standalone ACM interop jobs |
| `^lp-chaos--ACM--` | Future ACM chaos jobs |
| `^lp-ocp-compat--ACM--` | Future ACM ocp-compat jobs |

## Related
- openshift/release PR [#82108](https://github.com/openshift/release/pull/82108) — Adds `mpiit-data-router-reporter` step and `DR__RP__CR_COMP_NAME` to the ACM+Virt 4.22 P2P job
- JIRA: [INTEROP-9254](https://issues.redhat.com/browse/INTEROP-9254), [INTEROP-9256](https://issues.redhat.com/browse/INTEROP-9256)

## Note
The `LP--ACM` Jira component in OCPBUGS is now created