### PR TITLE
INTEROP-9281: Fix OPP LP Interop SuiteRegEx patterns

### DIFF
--- a/pkg/components/lpinteropoppackm/component.go
+++ b/pkg/components/lpinteropoppackm/component.go
@@ -17,7 +17,9 @@ var LPinteropOPPACMComponent = Component{
 		Operators:            []string{},
 		DefaultJiraComponent: "lp-interop--OPP-ACM",
 		Matchers: []config.ComponentMatcher{
-			{SuiteRegEx: regexp.MustCompile(`^lp-interop--OPP--acm-`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--OPP--Observability`)},
+			{SuiteRegEx: regexp.MustCompile(`^acm-opp-app$`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--OPP--acm`)},
 		},
 	},
 }

--- a/pkg/components/lpinteropoppodf/component.go
+++ b/pkg/components/lpinteropoppodf/component.go
@@ -17,7 +17,7 @@ var LPinteropOPPODFComponent = Component{
 		Operators:            []string{},
 		DefaultJiraComponent: "lp-interop--ODF",
 		Matchers: []config.ComponentMatcher{
-			{SuiteRegEx: regexp.MustCompile(`^lp-interop--OPP--interop-tests-ocs`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--OPP--pytest`)},
 		},
 	},
 }

--- a/pkg/components/lpinteropoppquay/component.go
+++ b/pkg/components/lpinteropoppquay/component.go
@@ -17,7 +17,7 @@ var LPinteropOPPQuayComponent = Component{
 		Operators:            []string{},
 		DefaultJiraComponent: "lp-interop--Quay",
 		Matchers: []config.ComponentMatcher{
-			{SuiteRegEx: regexp.MustCompile(`^lp-interop--OPP--quay-tests`)},
+			{SuiteRegEx: regexp.MustCompile(`^lp-interop--OPP--QUAY `)},
 		},
 	},
 }


### PR DESCRIPTION
## Summary
- Fix SuiteRegEx patterns for OPP CR components (ODF, Quay, ACM) to match actual JUnit suite names produced by the DR Reporter ExitTrap
- ODF: `^lp-interop--OPP--pytest` (was `^lp-interop--OPP--interop-tests-ocs`)
- Quay: `^lp-interop--OPP--QUAY ` with trailing space (was `^lp-interop--OPP--quay-tests`)
- ACM: 3 matchers — `^lp-interop--OPP--Observability`, `^acm-opp-app$`, `^lp-interop--OPP--acm` (was `^lp-interop--OPP--acm-`)

Validated against JUnit artifacts from job run 2085394982314708992.

Replaces #805 (closed — had unrelated data file churn from `make mapping`).

## Test plan
- [ ] CI checks pass (lint, mapping, unit)
- [ ] Verify regex patterns match actual JUnit suite names from GCS artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)