### PR TITLE
NO-JIRA: separate qe mappings target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,11 @@ test:
 mapping: build
 	# OCP Engineering
 	./ci-test-mapping map --mode=local
-	# QE
-	./ci-test-mapping map --bigquery-dataset ci_analysis_us --bigquery-project openshift-gce-devel --bigquery-dataset ci_analysis_qe --table-junit junit --table-mapping component_mapping --mode=local --config ""
 	# Verify mappings don't move anything into Unknown
+	./ci-test-mapping map-verify
+
+mapping-qe: build
+	./ci-test-mapping map --mode=bigquery --bigquery-project openshift-gce-devel --bigquery-dataset ci_analysis_qe --table-junit junit --table-mapping component_mapping --config ""
 	./ci-test-mapping map-verify
 
 unmapped:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ These are the general steps for updating a test's ownership:
    changes you see are expected.
 4. Commit the result and open a pull request on GitHub.
 
+Note: QE mappings (`make mapping-qe`) require BigQuery access to pull
+job variant data. Set the `GOOGLE_APPLICATION_CREDENTIALS` environment
+variable to your service account credential file before running:
+
+```
+export GOOGLE_APPLICATION_CREDENTIALS=~/bq.json
+make mapping-qe
+```
+
 If you'd like to annotate a test as having additional capabilities,
 update `capabilities.go`. A test may have multiple capabilities, but it
 can only belong to a single component.
@@ -128,7 +137,6 @@ For production, use `--mode bigquery` and provide credentials:
 ci-test-mapping map --mode bigquery \
   --google-service-account-credential-file ~/bq.json \
   --log-level debug \
-  --mapping-file mapping.json \
   --push-to-bigquery
 ```
 


### PR DESCRIPTION
Isolating qe mapping make target as it requires BQ for variants.

TestInfo.Variants has json:"-" tag (pkg/api/types/v1/component.go:44), which excludes variants from JSON serialization. When BigQuery mode runs, it fetches tests with variants populated (via a SQL JOIN with job_variants), assigns LEVEL0 capability to tests that have the Procedure:automated-release
  variant, and writes component_mapping.json correctly. But when it writes junit.json, the variants are stripped out by json:"-".

When local mode reads junit.json, all tests have no variants, so HasVariant(test, "Procedure:automated-release") always returns false, LEVEL0 is never assigned, and the fallback DefaultCapability = "Other" is used instead
