### PR TITLE
WIP: Add TestRename for kubelet TLS configuration test

### DIFF
--- a/pkg/components/node/kubelet/component.go
+++ b/pkg/components/node/kubelet/component.go
@@ -76,6 +76,7 @@ var KubeletComponent = Component{
 			"[sig-node] pathological event NodeHasSufficientPID condition does not occur too often":                                                                                                     "[sig-node] Test the NodeHasSufficientPID condition does not occur too often",
 			"[sig-builds][sig-node][Feature:Builds][apigroup:build.openshift.io] zstd:chunked Image should successfully run date command [Skipped:Disconnected] [Suite:openshift/conformance/parallel]": "[sig-node][Feature:Builds][apigroup:build.openshift.io] zstd:chunked Image should successfully run date command [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 			"[sig-node] zstd:chunked Image should successfully run date command [Skipped:Disconnected] [Suite:openshift/conformance/parallel]":                                                          "[sig-builds][sig-node][Feature:Builds][apigroup:build.openshift.io] zstd:chunked Image should successfully run date command [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+			"[sig-node][Serial] Kubelet TLS configuration should upgrade kubelet TLS from 1.2 to 1.3 on a custom pool [apigroup:machineconfiguration.openshift.io]":                                       "[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] Kubelet TLS configuration should upgrade kubelet TLS from 1.2 to 1.3 on a custom pool [apigroup:machineconfiguration.openshift.io] [Serial]",
 		},
 	},
 }


### PR DESCRIPTION
Map the renamed test "[sig-node][Serial] Kubelet TLS configuration should upgrade kubelet TLS from 1.2 to 1.3 on a custom pool" to its old name so Component Readiness can track it across the rename in openshift/origin PR #31547.

test renamed in https://github.com/openshift/origin/pull/31547

<!--

Thanks for contributing to ci-test-mapping.

Please make sure to run `make mapping` and commit the results when
making changes to test ownership. To have your PR's tested
automatically, join the openshift-eng GitHub organization. See the
instructions on #forum-pge-cloud-ops on Slack.

Please see README.md for additional information how about
this repo works.

-->
